### PR TITLE
Social uploads default to Inactive

### DIFF
--- a/api/src/main/scala/com/gu/core/store/store.scala
+++ b/api/src/main/scala/com/gu/core/store/store.scala
@@ -5,7 +5,6 @@ import java.util.UUID
 
 import com.amazonaws.regions.Region
 import com.amazonaws.services.s3.model.ObjectMetadata
-import com.gu.core.models
 import com.gu.core.models.Errors._
 import com.gu.core.models._
 import com.gu.core.utils.ErrorHandling.logIfError

--- a/api/src/main/scala/com/gu/core/store/store.scala
+++ b/api/src/main/scala/com/gu/core/store/store.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 
 import com.amazonaws.regions.Region
 import com.amazonaws.services.s3.model.ObjectMetadata
+import com.gu.core.models
 import com.gu.core.models.Errors._
 import com.gu.core.models._
 import com.gu.core.utils.ErrorHandling.logIfError
@@ -122,6 +123,7 @@ case class AvatarStore(fs: FileStore, kvs: KVStore, props: StoreProperties) exte
     val avatarId = UUID.randomUUID
     val now = DateTime.now(DateTimeZone.UTC)
     val location = KVLocationFromID(avatarId.toString)
+    val status = if (isSocial) Inactive else Pending
 
     val created = for {
       secureUrl <- fs.presignedUrl(processedBucket, location)
@@ -134,7 +136,7 @@ case class AvatarStore(fs: FileStore, kvs: KVStore, props: StoreProperties) exte
           userId = user.id,
           originalFilename = originalFilename,
           rawUrl = secureRawUrl.toString,
-          status = Pending,
+          status = status,
           createdAt = now,
           lastModified = now,
           isSocial = isSocial,

--- a/api/src/test/scala/com/gu/adapters/http/AvatarServletTests.scala
+++ b/api/src/test/scala/com/gu/adapters/http/AvatarServletTests.scala
@@ -84,10 +84,24 @@ class AvatarServletTests extends TestHelpers {
     postAvatar(
       "/avatars",
       file,
+      "false",
+      userId,
+      cookie,
+      a => a.data.userId == userId && a.data.status == Pending && !a.data.isActive && !a.data.isSocial
+    )
+  }
+
+  test("Social Avatar should default to Inactive status") {
+    val file = new File("src/test/resources/avatar.gif")
+    val (userId, cookie) = testCookie
+
+    postAvatar(
+      "/avatars",
+      file,
       "true",
       userId,
       cookie,
-      a => a.data.userId == userId && a.data.status == Pending && !a.data.isActive && a.data.isSocial
+      a => a.data.userId == userId && a.data.status == Inactive && !a.data.isActive && a.data.isSocial
     )
   }
 


### PR DESCRIPTION
All user uploads were defaulting to Pending. This changes the behaviour so that Social users default to Inactive, as we do not want their avatars sent for moderation initially.