### PR TITLE
Support SC_GU_U cookie

### DIFF
--- a/api/src/main/scala/com/gu/adapters/http/Authentication.scala
+++ b/api/src/main/scala/com/gu/adapters/http/Authentication.scala
@@ -29,12 +29,19 @@ object CookieDecoder {
   def userFromHeader(decoder: GuUDecoder, authHeader: Option[String]): Error \/ User = {
     val guu = authHeader.map(_.stripPrefix("Bearer cookie="))
 
-    val user = for {
+    // TODO remove support for GU_U once confident SC_GU_U works and clients have switched over
+    val guuUser = for {
       cook <- guu.toRightDisjunction("No GU_U cookie in request")
       user <- attempt(decoder.getUserDataForGuU(cook)).toOption.flatten.map(_.user)
         .toRightDisjunction("Unable to extract user data from Authorization header")
     } yield User(user.id.toInt)
 
-    user.leftMap(error => userAuthorizationFailed(NonEmptyList(error)))
+    val scguuUser = for {
+      cook <- guu.toRightDisjunction("No SC_GU_U cookie in request")
+      user <- attempt(decoder.getUserDataForScGuU(cook)).toOption.flatten
+        .toRightDisjunction("Unable to extract user data from Authorization header")
+    } yield User(user.getId.toInt)
+
+    guuUser.orElse(scguuUser).leftMap(error => userAuthorizationFailed(NonEmptyList(error)))
   }
 }

--- a/api/src/main/scala/com/gu/adapters/http/Authentication.scala
+++ b/api/src/main/scala/com/gu/adapters/http/Authentication.scala
@@ -31,14 +31,14 @@ object CookieDecoder {
 
     // TODO remove support for GU_U once confident SC_GU_U works and clients have switched over
     val guuUser = for {
-      cook <- guu.toRightDisjunction("No GU_U cookie in request")
-      user <- attempt(decoder.getUserDataForGuU(cook)).toOption.flatten.map(_.user)
+      cookie <- guu.toRightDisjunction("No GU_U cookie in request")
+      user <- attempt(decoder.getUserDataForGuU(cookie)).toOption.flatten.map(_.user)
         .toRightDisjunction("Unable to extract user data from Authorization header")
     } yield User(user.id.toInt)
 
     val scguuUser = for {
-      cook <- guu.toRightDisjunction("No SC_GU_U cookie in request")
-      user <- attempt(decoder.getUserDataForScGuU(cook)).toOption.flatten
+      cookie <- guu.toRightDisjunction("No SC_GU_U cookie in request")
+      user <- attempt(decoder.getUserDataForScGuU(cookie)).toOption.flatten
         .toRightDisjunction("Unable to extract user data from Authorization header")
     } yield User(user.getId.toInt)
 

--- a/api/src/main/scala/com/gu/adapters/http/AvatarServlet.scala
+++ b/api/src/main/scala/com/gu/adapters/http/AvatarServlet.scala
@@ -151,7 +151,7 @@ class AvatarServlet(store: AvatarStore, publisher: Publisher, props: AvatarServl
     } yield (updated, req)
   }
 
-  def handleSuccess: PartialFunction[\/[Error, (Success, Req)], ActionResult] = {
+  def handleSuccess: PartialFunction[Error \/ (Success, Req), ActionResult] = {
     case \/-((success, url)) => success match {
       case CreatedAvatar(avatar) => Created(AvatarResponse(avatar, url))
       case FoundAvatar(avatar) => Ok(AvatarResponse(avatar, url))
@@ -162,7 +162,6 @@ class AvatarServlet(store: AvatarStore, publisher: Publisher, props: AvatarServl
 
   def handleError[A]: PartialFunction[\/[Error, A], ActionResult] = {
     case -\/(error) =>
-
       val response: ActionResult =
         error match {
           case InvalidContentType(msg, errors) => UnsupportedMediaType(ErrorResponse(msg, errors))

--- a/api/src/test/scala/com/gu/adapters/http/AuthenticationTests.scala
+++ b/api/src/test/scala/com/gu/adapters/http/AuthenticationTests.scala
@@ -10,12 +10,18 @@ class AuthenticationTests extends FunSuite with Matchers {
   val decoder = StubGuUDecoder
 
   test("Decode GU_U cookie from Authorization header") {
-    val authHeader = "Bearer cookie=" + TestCookie.cookieData
+    val authHeader = "Bearer cookie=" + TestCookie.fakeGuu
     val user = CookieDecoder.userFromHeader(decoder, Some(authHeader))
     user should be(\/-(User(TestCookie.userId)))
   }
 
-  test("Reject invalid GU_U cookie") {
+  test("Decode SC_GU_U cookie from Authorization header") {
+    val authHeader = "Bearer cookie=" + TestCookie.fakeScguu
+    val user = CookieDecoder.userFromHeader(decoder, Some(authHeader))
+    user should be(\/-(User(TestCookie.userId)))
+  }
+
+  test("Reject invalid cookie") {
     val authHeader = "Bearer cookie=" + "20394sdkfjs23slkdjfslkjdf234slkdjfsd-23"
     val user = CookieDecoder.userFromHeader(decoder, Some(authHeader))
     user.isLeft should be(true)

--- a/api/src/test/scala/com/gu/adapters/http/TestCookie.scala
+++ b/api/src/test/scala/com/gu/adapters/http/TestCookie.scala
@@ -5,17 +5,26 @@ import com.gu.identity.model.User
 
 object TestCookie {
   val userId = 654321
-  val cookieData = "valid_cookie"
-  val testCookie = userId -> cookieData
+  val fakeGuu = "valid-gu-u"
+  val fakeScguu = "valid-sc-gu-u"
+  val testCookie = userId -> fakeScguu
 }
 
 object StubGuUDecoder extends GuUDecoder(null) {
   import TestCookie._
 
   override def getUserDataForGuU(cookieValue: String): Option[GuUCookieData] = {
-    if (cookieValue contains cookieData) {
+    if (cookieValue contains fakeGuu) {
       val user = User().copy(primaryEmailAddress = "user@test.com", id = userId.toString)
       Some(GuUCookieData(user, 0, None))
+    } else
+      None
+  }
+
+  override def getUserDataForScGuU(cookieValue: String): Option[User] = {
+    if (cookieValue contains fakeScguu) {
+      val user = User().copy(primaryEmailAddress = "user@test.com", id = userId.toString)
+      Some(user)
     } else
       None
   }


### PR DESCRIPTION
GU_U is deprecated; we need to migrate to the SC_GU_U (secure) cookie. This commit supports both, allowing us to migrate clients safely, after which we'll remove GU_U support entirely.