### PR TITLE
Read secure cookie directly

### DIFF
--- a/api/src/main/scala/com/gu/adapters/config/Config.scala
+++ b/api/src/main/scala/com/gu/adapters/config/Config.scala
@@ -18,6 +18,8 @@ object Config {
 
   private val pageSize = 10
 
+  val secureCookie = "SC_GU_U"
+
   def apply(): Config = {
     apply(ConfigFactory.load())
   }

--- a/api/src/main/scala/com/gu/adapters/http/AvatarServlet.scala
+++ b/api/src/main/scala/com/gu/adapters/http/AvatarServlet.scala
@@ -1,6 +1,7 @@
 package com.gu.adapters.http
 
-import com.gu.adapters.http.CookieDecoder.userFromHeader
+import com.gu.adapters.config.Config
+import com.gu.adapters.http.CookieDecoder.userFromHeaderOrCookie
 import com.gu.adapters.http.Image._
 import com.gu.adapters.notifications.{ Notifications, Publisher }
 import com.gu.core.models.Errors._
@@ -126,7 +127,7 @@ class AvatarServlet(store: AvatarStore, publisher: Publisher, props: AvatarServl
 
   getWithErrors("/avatars/user/me/active", operation(getPersonalAvatarForUser)) {
     for {
-      user <- userFromHeader(decoder, request.header("Authorization"))
+      user <- userFromHeaderOrCookie(decoder, request.header("Authorization"), request.cookies.get(Config.secureCookie))
       avatar <- store.getPersonal(user)
       req = Req(apiUrl, request.getPathInfo)
     } yield (avatar, req)
@@ -134,7 +135,7 @@ class AvatarServlet(store: AvatarStore, publisher: Publisher, props: AvatarServl
 
   postWithErrors("/avatars", operation(postAvatar)) {
     for {
-      user <- userFromHeader(decoder, request.header("Authorization"))
+      user <- userFromHeaderOrCookie(decoder, request.header("Authorization"), request.cookies.get(Config.secureCookie))
       created <- uploadAvatar(request, user, fileParams)
       req = Req(apiUrl, request.getPathInfo)
     } yield {

--- a/api/src/test/scala/com/gu/adapters/http/AuthenticationTests.scala
+++ b/api/src/test/scala/com/gu/adapters/http/AuthenticationTests.scala
@@ -15,9 +15,8 @@ class AuthenticationTests extends FunSuite with Matchers {
     user should be(\/-(User(TestCookie.userId)))
   }
 
-  test("Decode SC_GU_U cookie from Authorization header") {
-    val authHeader = "Bearer cookie=" + TestCookie.fakeScguu
-    val user = CookieDecoder.userFromHeader(decoder, Some(authHeader))
+  test("Decode SC_GU_U cookie from cookie") {
+    val user = CookieDecoder.userFromCookie(decoder, Some(TestCookie.fakeScguu))
     user should be(\/-(User(TestCookie.userId)))
   }
 

--- a/api/src/test/scala/com/gu/adapters/http/AvatarServletTests.scala
+++ b/api/src/test/scala/com/gu/adapters/http/AvatarServletTests.scala
@@ -8,7 +8,7 @@ import com.gu.adapters.store.{ TestFileStore, TestKVStore }
 import com.gu.core.models.{ Approved, Inactive, Pending, Rejected }
 import com.gu.core.store.AvatarStore
 import com.gu.utils.TestHelpers
-import com.gu.adapters.http.TestCookie.testCookie
+import com.gu.adapters.http.TestCookie.{ testCookie, testSecureCookie }
 
 class AvatarServletTests extends TestHelpers {
 
@@ -107,7 +107,7 @@ class AvatarServletTests extends TestHelpers {
 
   test("Error response if bad isSocial parameter") {
     val file = new File("src/test/resources/avatar.gif")
-    val (userId, cookie) = testCookie
+    val (userId, cookie) = testSecureCookie
 
     postError(
       "/avatars",

--- a/api/src/test/scala/com/gu/adapters/http/TestCookie.scala
+++ b/api/src/test/scala/com/gu/adapters/http/TestCookie.scala
@@ -7,7 +7,8 @@ object TestCookie {
   val userId = 654321
   val fakeGuu = "valid-gu-u"
   val fakeScguu = "valid-sc-gu-u"
-  val testCookie = userId -> fakeScguu
+  val testCookie = userId -> fakeGuu
+  val testSecureCookie = userId -> fakeScguu
 }
 
 object StubGuUDecoder extends GuUDecoder(null) {

--- a/api/src/test/scala/com/gu/utils/TestHelpers.scala
+++ b/api/src/test/scala/com/gu/utils/TestHelpers.scala
@@ -105,11 +105,11 @@ trait TestHelpers extends ScalatraSuite with FunSuiteLike {
     file: File,
     isSocial: String,
     userId: Int,
-    guuCookie: String,
+    cookie: String,
     code: Int,
     p: ErrorResponse => Boolean
   ): Unit = {
-    post(uri, Map("isSocial" -> isSocial), List("file" -> file), Map("Authorization" -> ("Bearer cookie=" + guuCookie))) {
+    post(uri, Map("isSocial" -> isSocial), List("file" -> file), Map("Cookie" -> s"SC_GU_U=$cookie;")) {
       status should equal(code)
       val error = read[ErrorResponse](body)
       p(error) should be(true)


### PR DESCRIPTION
It was expected that we would read this cookie from the auth header. However, as requests will now come direct and not via a proxy we need to read the cookie directly.