### PR TITLE
Revert "Support personal avatars from active-by-ID endpoint"

### DIFF
--- a/api/src/main/scala/com/gu/adapters/http/AvatarServlet.scala
+++ b/api/src/main/scala/com/gu/adapters/http/AvatarServlet.scala
@@ -119,13 +119,8 @@ class AvatarServlet(store: AvatarStore, publisher: Publisher, props: AvatarServl
 
   apiGet("/avatars/user/:userId/active", operation(getActiveAvatarForUser)) { auth =>
     for {
-      requestedUser <- userFromRequest(params("userId"))
-      user = userFromCookie(decoder, request.cookies.get(Config.secureCookie))
-      active <- if (user.exists(_.id == requestedUser.id)) {
-        store.getPersonal(requestedUser)
-      } else {
-        store.getActive(requestedUser)
-      }
+      user <- userFromRequest(params("userId"))
+      active <- store.getActive(user)
       req = Req(apiUrl, request.getPathInfo)
     } yield (active, req)
   }


### PR DESCRIPTION
Reverts guardian/discussion-avatar#7

I don't think this is needed in fact, as we do have a way to detect userId in frontend (albeit, the underlying mechanism which is GU_U will change soon). See: https://github.com/guardian/frontend/pull/11849.