### PR TITLE
Add order by asc or desc to avatars endpoint

### DIFF
--- a/api/src/main/scala/com/gu/adapters/http/Filter.scala
+++ b/api/src/main/scala/com/gu/adapters/http/Filter.scala
@@ -33,11 +33,19 @@ object Filter {
       case None => Success(None)
     }
 
+    val order: Validation[NonEmptyList[String], OrderBy] = params.get("order") match {
+      case Some(Descending.asString) => Success(Descending)
+      case Some(Ascending.asString) => Success(Ascending)
+      case Some(invalid) => Failure(NonEmptyList(""))
+      case None => Success(Descending)
+    }
+
     val filters = for {
       s <- status
       f <- since
       b <- until
-    } yield Filters(s, f, b)
+      o <- order
+    } yield Filters(s, f, b, o)
 
     filters
       .ensure(NonEmptyList("Cannot specify both 'since' and 'until' parameters"))(f => f.since.isEmpty || f.until.isEmpty)

--- a/api/src/main/scala/com/gu/adapters/http/Filter.scala
+++ b/api/src/main/scala/com/gu/adapters/http/Filter.scala
@@ -33,11 +33,11 @@ object Filter {
       case None => Success(None)
     }
 
-    val order: Validation[NonEmptyList[String], OrderBy] = params.get("order") match {
-      case Some(Descending.asString) => Success(Descending)
-      case Some(Ascending.asString) => Success(Ascending)
-      case Some(invalid) => Failure(NonEmptyList(""))
-      case None => Success(Descending)
+    val order: Validation[NonEmptyList[String], Option[OrderBy]] = params.get("order") match {
+      case Some(Descending.asString) => Success(Some(Descending))
+      case Some(Ascending.asString) => Success(Some(Ascending))
+      case Some(invalid) => Failure(NonEmptyList(s"'$invalid' is not a valid order type. Must be '${Ascending.asString}' or '${Descending.asString}' (default)."))
+      case None => Success(None)
     }
 
     val filters = for {
@@ -56,7 +56,8 @@ object Filter {
     val params = List(
       "status" -> Some(f.status.asString),
       "since" -> f.since.map(t => ISODateFormatter.print(t)),
-      "until" -> f.until.map(t => ISODateFormatter.print(t))
+      "until" -> f.until.map(t => ISODateFormatter.print(t)),
+      "order" -> f.order.map(_.asString)
     ) collect {
         case (key, Some(value)) => s"$key=$value"
       }

--- a/api/src/main/scala/com/gu/adapters/http/Req.scala
+++ b/api/src/main/scala/com/gu/adapters/http/Req.scala
@@ -1,8 +1,8 @@
 package com.gu.adapters.http
 
-import com.gu.core.models.{ Approved, Filters }
+import com.gu.core.models.{ Approved, Filters, Descending }
 
-case class Req(base: String, path: String, filters: Filters = Filters(Approved, None, None))
+case class Req(base: String, path: String, filters: Filters = Filters(Approved, None, None, Descending))
 
 object Req {
   def toString(req: Req): String = {

--- a/api/src/main/scala/com/gu/adapters/http/Req.scala
+++ b/api/src/main/scala/com/gu/adapters/http/Req.scala
@@ -2,7 +2,7 @@ package com.gu.adapters.http
 
 import com.gu.core.models.{ Approved, Filters, Descending }
 
-case class Req(base: String, path: String, filters: Filters = Filters(Approved, None, None, Descending))
+case class Req(base: String, path: String, filters: Filters = Filters(Approved, None, None, None))
 
 object Req {
   def toString(req: Req): String = {

--- a/api/src/main/scala/com/gu/core/models/Filters.scala
+++ b/api/src/main/scala/com/gu/core/models/Filters.scala
@@ -5,5 +5,6 @@ import org.joda.time.DateTime
 case class Filters(
   status: Status,
   since: Option[DateTime],
-  until: Option[DateTime]
+  until: Option[DateTime],
+  order: OrderBy
 )

--- a/api/src/main/scala/com/gu/core/models/Filters.scala
+++ b/api/src/main/scala/com/gu/core/models/Filters.scala
@@ -6,5 +6,5 @@ case class Filters(
   status: Status,
   since: Option[DateTime],
   until: Option[DateTime],
-  order: OrderBy
+  order: Option[OrderBy]
 )

--- a/api/src/main/scala/com/gu/core/models/order.scala
+++ b/api/src/main/scala/com/gu/core/models/order.scala
@@ -1,0 +1,13 @@
+package com.gu.core.models
+
+sealed trait OrderBy { def asString: String }
+case object Ascending extends OrderBy { val asString = "asc" }
+case object Descending extends OrderBy { val asString = "desc" }
+
+object OrderBy {
+
+  def apply(order: String): OrderBy = order match {
+    case "asc" => Ascending
+    case "desc" => Descending
+  }
+}

--- a/api/src/main/scala/com/gu/core/store/store.scala
+++ b/api/src/main/scala/com/gu/core/store/store.scala
@@ -23,7 +23,7 @@ case class QueryResponse(
 trait KVStore {
   def get(table: String, id: String): Error \/ Avatar
   def query(table: String, index: String, userId: Int, since: Option[DateTime], until: Option[DateTime]): Error \/ QueryResponse
-  def query(table: String, index: String, status: Status, since: Option[DateTime], until: Option[DateTime], order: OrderBy): Error \/ QueryResponse
+  def query(table: String, index: String, status: Status, since: Option[DateTime], until: Option[DateTime], order: Option[OrderBy]): Error \/ QueryResponse
   def put(table: String, avatar: Avatar): Error \/ Avatar
   def update(table: String, id: String, status: Status, isActive: Boolean = false): Error \/ Avatar
 }

--- a/api/src/main/scala/com/gu/core/store/store.scala
+++ b/api/src/main/scala/com/gu/core/store/store.scala
@@ -23,7 +23,7 @@ case class QueryResponse(
 trait KVStore {
   def get(table: String, id: String): Error \/ Avatar
   def query(table: String, index: String, userId: Int, since: Option[DateTime], until: Option[DateTime]): Error \/ QueryResponse
-  def query(table: String, index: String, status: Status, since: Option[DateTime], until: Option[DateTime]): Error \/ QueryResponse
+  def query(table: String, index: String, status: Status, since: Option[DateTime], until: Option[DateTime], order: OrderBy): Error \/ QueryResponse
   def put(table: String, avatar: Avatar): Error \/ Avatar
   def update(table: String, id: String, status: Status, isActive: Boolean = false): Error \/ Avatar
 }
@@ -64,7 +64,7 @@ case class AvatarStore(fs: FileStore, kvs: KVStore, props: StoreProperties) exte
 
   def get(filters: Filters): \/[Error, FoundAvatars] = {
     for {
-      qr <- kvs.query(dynamoTable, statusIndex, filters.status, filters.since, filters.until)
+      qr <- kvs.query(dynamoTable, statusIndex, filters.status, filters.since, filters.until, filters.order)
     } yield FoundAvatars(qr.avatars, qr.hasMore)
   }
 

--- a/api/src/test/scala/com/gu/adapters/store/store.scala
+++ b/api/src/test/scala/com/gu/adapters/store/store.scala
@@ -127,7 +127,7 @@ class TestKVStore(dynamoTable: String) extends KVStore {
     QueryResponse(docs.values.filter(_.userId == userId).toList, hasMore = false).right
   }
 
-  def query(table: String, index: String, status: Status, since: Option[DateTime], until: Option[DateTime]): models.Error \/ QueryResponse = {
+  def query(table: String, index: String, status: Status, since: Option[DateTime], until: Option[DateTime], order: Option[OrderBy]): models.Error \/ QueryResponse = {
     QueryResponse(docs.values.filter(_.status == status).toList, hasMore = false).right
   }
 


### PR DESCRIPTION
The ability to list avatars pending approval in descending order is needed for modtools v2. The moderators have requested that pending avatars be displayed from oldest to newest so that they review avatars that have been in the queue the longest first.

The param `order` and values `asc` and `desc` were chosen because they align with the GitHub API which the `since` and `until` paging are modelled on.