### PR TITLE
UserId should be a string not an int

### DIFF
--- a/api/src/main/scala/com/gu/adapters/http/Authentication.scala
+++ b/api/src/main/scala/com/gu/adapters/http/Authentication.scala
@@ -39,6 +39,6 @@ object CookieDecoder {
     for {
       user <- attempt(decoder.getUserDataForScGuU(cookie))
         .toOption.flatten.toRightDisjunction("Unable to extract user data from cookie")
-    } yield User(user.getId.toInt)
+    } yield User(user.getId)
   }
 }

--- a/api/src/main/scala/com/gu/adapters/http/AvatarServlet.scala
+++ b/api/src/main/scala/com/gu/adapters/http/AvatarServlet.scala
@@ -221,8 +221,8 @@ class AvatarServlet(store: AvatarStore, publisher: Publisher, props: AvatarServl
   }
 
   def userFromRequest(userId: String): Error \/ User = {
-    attempt(User(userId.toInt))
-      .leftMap(_ => invalidUserId(NonEmptyList("Expected integer, found: " + userId)))
+    attempt(User(userId))
+      .leftMap(_ => invalidUserId(NonEmptyList("Expected userId, found: " + userId)))
   }
 }
 

--- a/api/src/main/scala/com/gu/adapters/store/Store.scala
+++ b/api/src/main/scala/com/gu/adapters/store/Store.scala
@@ -57,7 +57,7 @@ case class Dynamo(db: DynamoDB, fs: FileStore, props: DynamoProperties) extends 
       Avatar(
         id = avatarId,
         avatarUrl = secureUrl.toString,
-        userId = item.getString("UserId").toInt,
+        userId = item.getString("UserId"),
         originalFilename = item.getString("OriginalFilename"),
         rawUrl = secureRawUrl.toString,
         status = Status(item.getString("Status")),
@@ -119,8 +119,8 @@ case class Dynamo(db: DynamoDB, fs: FileStore, props: DynamoProperties) extends 
     }
   }
 
-  def query(table: String, index: String, userId: Int, since: Option[DateTime], until: Option[DateTime]): Error \/ QueryResponse = {
-    query(table, index, "UserId", userId, since, until)
+  def query(table: String, index: String, userId: String, since: Option[DateTime], until: Option[DateTime]): Error \/ QueryResponse = {
+    query(table, index, "UserId", userId.toInt, since, until)
   }
 
   def query(table: String, index: String, status: Status, since: Option[DateTime], until: Option[DateTime], order: Option[OrderBy]): Error \/ QueryResponse = {
@@ -130,7 +130,7 @@ case class Dynamo(db: DynamoDB, fs: FileStore, props: DynamoProperties) extends 
   def put(table: String, avatar: Avatar): Error \/ Avatar = {
     val item = new Item()
       .withPrimaryKey("AvatarId", avatar.id)
-      .withNumber("UserId", avatar.userId)
+      .withNumber("UserId", avatar.userId.toInt)
       .withString("OriginalFilename", avatar.originalFilename)
       .withString("Status", avatar.status.asString)
       .withString("CreatedAt", ISODateFormatter.print(avatar.createdAt))

--- a/api/src/main/scala/com/gu/core/models/Avatar.scala
+++ b/api/src/main/scala/com/gu/core/models/Avatar.scala
@@ -5,7 +5,7 @@ import org.joda.time.DateTime
 case class Avatar(
   id: String,
   avatarUrl: String,
-  userId: Int,
+  userId: String,
   originalFilename: String,
   rawUrl: String,
   status: Status,

--- a/api/src/main/scala/com/gu/core/models/User.scala
+++ b/api/src/main/scala/com/gu/core/models/User.scala
@@ -1,3 +1,3 @@
 package com.gu.core.models
 
-case class User(id: Int)
+case class User(id: String)

--- a/api/src/main/scala/com/gu/core/store/store.scala
+++ b/api/src/main/scala/com/gu/core/store/store.scala
@@ -22,7 +22,7 @@ case class QueryResponse(
 
 trait KVStore {
   def get(table: String, id: String): Error \/ Avatar
-  def query(table: String, index: String, userId: Int, since: Option[DateTime], until: Option[DateTime]): Error \/ QueryResponse
+  def query(table: String, index: String, userId: String, since: Option[DateTime], until: Option[DateTime]): Error \/ QueryResponse
   def query(table: String, index: String, status: Status, since: Option[DateTime], until: Option[DateTime], order: Option[OrderBy]): Error \/ QueryResponse
   def put(table: String, avatar: Avatar): Error \/ Avatar
   def update(table: String, id: String, status: Status, isActive: Boolean = false): Error \/ Avatar
@@ -132,7 +132,7 @@ case class AvatarStore(fs: FileStore, kvs: KVStore, props: StoreProperties) exte
         Avatar(
           id = avatarId.toString,
           avatarUrl = secureUrl.toString,
-          userId = user.id,
+          userId = user.id.toString,
           originalFilename = originalFilename,
           rawUrl = secureRawUrl.toString,
           status = status,
@@ -154,14 +154,14 @@ case class AvatarStore(fs: FileStore, kvs: KVStore, props: StoreProperties) exte
       processedBucket,
       location,
       publicBucket,
-      s"user/${avatar.userId.toString}"
+      s"user/${avatar.userId}"
     ) map (_ => avatar)
   }
 
   def deleteFromPublic(avatar: Avatar): Error \/ Avatar = {
     fs.delete(
       publicBucket,
-      s"user/${avatar.userId.toString}"
+      s"user/${avatar.userId}"
     ) map (_ => avatar)
   }
 

--- a/api/src/test/scala/com/gu/adapters/http/TestCookie.scala
+++ b/api/src/test/scala/com/gu/adapters/http/TestCookie.scala
@@ -4,7 +4,7 @@ import com.gu.identity.cookie.GuUDecoder
 import com.gu.identity.model.User
 
 object TestCookie {
-  val userId = 654321
+  val userId = "654321"
   val fakeScguu = "valid-sc-gu-u"
   val testSecureCookie = userId -> fakeScguu
 }
@@ -14,7 +14,7 @@ object StubGuUDecoder extends GuUDecoder(null) {
 
   override def getUserDataForScGuU(cookieValue: String): Option[User] = {
     if (cookieValue contains fakeScguu) {
-      val user = User().copy(primaryEmailAddress = "user@test.com", id = userId.toString)
+      val user = User().copy(primaryEmailAddress = "user@test.com", id = userId)
       Some(user)
     } else
       None

--- a/api/src/test/scala/com/gu/adapters/store/store.scala
+++ b/api/src/test/scala/com/gu/adapters/store/store.scala
@@ -72,7 +72,7 @@ class TestKVStore(dynamoTable: String) extends KVStore {
     dynamoTable + "/9f51970f-fc24-400a-9ceb-9b347d9b5e5e" -> Avatar(
       "9f51970f-fc24-400a-9ceb-9b347d9b5e5e",
       "http://avatar-url-1",
-      123456,
+      "123456",
       "foo.gif",
       "http://avatar-raw-url1",
       Approved,
@@ -84,7 +84,7 @@ class TestKVStore(dynamoTable: String) extends KVStore {
     dynamoTable + "/5aa5aa52-ee78-4319-8fa0-93bfd1dc204b" -> Avatar(
       "5aa5aa52-ee78-4319-8fa0-93bfd1dc204b",
       "http://avatar-url-2",
-      234567,
+      "234567",
       "bar.gif",
       "http://avatar-raw-url2",
       Approved,
@@ -96,7 +96,7 @@ class TestKVStore(dynamoTable: String) extends KVStore {
     dynamoTable + "/f1d07680-fd11-492c-9bbf-fc996b435590" -> Avatar(
       "f1d07680-fd11-492c-9bbf-fc996b435590",
       "http://avatar-url-3",
-      345678,
+      "345678",
       "gra.gif",
       "http://avatar-raw-url3",
       Pending,
@@ -123,7 +123,7 @@ class TestKVStore(dynamoTable: String) extends KVStore {
     docs.get(path(table, id)).toRightDisjunction(avatarNotFound(NonEmptyList(s"avatar with ID '$id' does not exist")))
   }
 
-  def query(table: String, index: String, userId: Int, since: Option[DateTime], until: Option[DateTime]): models.Error \/ QueryResponse = {
+  def query(table: String, index: String, userId: String, since: Option[DateTime], until: Option[DateTime]): models.Error \/ QueryResponse = {
     QueryResponse(docs.values.filter(_.userId == userId).toList, hasMore = false).right
   }
 

--- a/api/src/test/scala/com/gu/utils/TestHelpers.scala
+++ b/api/src/test/scala/com/gu/utils/TestHelpers.scala
@@ -87,7 +87,7 @@ trait TestHelpers extends ScalatraSuite with FunSuiteLike {
     uri: String,
     file: File,
     isSocial: String,
-    userId: Int,
+    userId: String,
     cookie: String,
     p: AvatarResponse => Boolean
   ): Unit = {
@@ -104,7 +104,7 @@ trait TestHelpers extends ScalatraSuite with FunSuiteLike {
     uri: String,
     file: File,
     isSocial: String,
-    userId: Int,
+    userId: String,
     cookie: String,
     code: Int,
     p: ErrorResponse => Boolean


### PR DESCRIPTION
UserId is universally treated as a *string* across all Guardian APIs. I'm not sure why we made it an `Int` for Avatar API but it's adding unnecessary complexity to the Modtools API with the translations back and forth.

This PR leaves the DynamoDB tables untouched but converts the UserId `Int` to a `String` when interacting with the DB and is handled as a string everywhere, including in API responses.