### PR TITLE
Log requests and use JSON format

### DIFF
--- a/api/project/build.scala
+++ b/api/project/build.scala
@@ -16,7 +16,8 @@ object AvatarBuild extends Build {
   
   val jettyVersion = "9.1.5.v20140505"
   val json4sVersion = "3.2.10"
-  val logbackVersion = "1.1.3"
+  val logbackVersion = "1.1.6"
+  val logstashEncoderVersion = "4.6"
   val servletApiVersion = "3.1.0"
   val scalazVersion = "7.1.1"
   val identityCookieVersion = "3.44"
@@ -41,6 +42,8 @@ object AvatarBuild extends Build {
       libraryDependencies ++= Seq(
         "org.scalatra" %% "scalatra" % ScalatraVersion,
         "ch.qos.logback" % "logback-classic" % logbackVersion,
+        "ch.qos.logback" % "logback-access" % logbackVersion,
+        "net.logstash.logback" % "logstash-logback-encoder" % logstashEncoderVersion,
         "org.eclipse.jetty" % "jetty-webapp" % jettyVersion % "container;compile",
         "org.eclipse.jetty" % "jetty-plus" % jettyVersion % "container",
         "javax.servlet" % "javax.servlet-api" % servletApiVersion,
@@ -55,7 +58,6 @@ object AvatarBuild extends Build {
         "com.amazonaws" % "aws-java-sdk" % amazonawsVersion,
         "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingVersion,
         "org.apache.commons" % "commons-lang3" % apacheCommonsVersion
-
       ),
       assemblyMergeStrategy in assembly := {
         case "version.txt" => MergeStrategy.discard

--- a/api/src/main/resources/logback-access.xml
+++ b/api/src/main/resources/logback-access.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashAccessEncoder" />
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>

--- a/api/src/main/resources/logback.xml
+++ b/api/src/main/resources/logback.xml
@@ -1,11 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <encoder>
-      <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
-    </encoder>
+    <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
   </appender>
 
-  <root level="info">
-    <appender-ref ref="STDOUT" />
+  <root level="INFO">
+    <appender-ref ref="STDOUT"/>
   </root>
+
 </configuration>

--- a/api/src/main/scala/com/gu/adapters/http/JettyLauncher.scala
+++ b/api/src/main/scala/com/gu/adapters/http/JettyLauncher.scala
@@ -4,6 +4,8 @@ import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.servlet.DefaultServlet
 import org.eclipse.jetty.webapp.WebAppContext
 import org.scalatra.servlet.ScalatraListener
+import ch.qos.logback.access.jetty.RequestLogImpl
+import org.eclipse.jetty.server.handler.{ HandlerCollection, RequestLogHandler }
 
 object JettyLauncher extends App {
 
@@ -16,7 +18,15 @@ object JettyLauncher extends App {
   context.addEventListener(new ScalatraListener)
   context.addServlet(classOf[DefaultServlet], "/")
 
-  server.setHandler(context)
+  val requestLog = new RequestLogImpl()
+  requestLog.setResource("/logback-access.xml")
+  val requestLogHandler = new RequestLogHandler()
+  requestLogHandler.setRequestLog(requestLog)
+
+  val handlers = new HandlerCollection()
+  handlers.setHandlers(Array(context, requestLogHandler))
+
+  server.setHandler(handlers)
 
   server.start
   server.join


### PR DESCRIPTION
* log access requests
* use JSON format for all logging

This is to standardise how we log things and prepare for aggregation via logstash to our ELK stack.