### PR TITLE
Update alpakka sqs dependency

### DIFF
--- a/api/build.sbt
+++ b/api/build.sbt
@@ -57,7 +57,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-dynamodb" % amazonawsVersion,
   "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingVersion,
   "org.apache.commons" % "commons-lang3" % apacheCommonsVersion,
-  "com.lightbend.akka" %% "akka-stream-alpakka-sqs" % "0.9",
+  "com.lightbend.akka" %% "akka-stream-alpakka-sqs" % "0.20",
   "com.gu" % "kinesis-logback-appender" % "1.4.2"
 )
 


### PR DESCRIPTION
**Cause of issue**
Following a detected spike in the avatar api log traffic we found that there was a bug in the akka-stream-alpakka-sqs version we were using. The effects of this bug became apparent when the api failed to delete an avatar, causing causing the SQS message to be requeued. However, the requeueWithDelay() method didn't act as expected, sending a copy of the message (with an identical body but different message id) back to the queue. This caused the queue to incessantly grow. See more information on the cause and effect [here](https://docs.google.com/document/d/1Iz9zPY5g8ks7QtVXO0EhwtwC0UAFZAgc6YBqhvNEQ-A/edit#bookmark=id.r71cava6k921). 

**The fix**
In order to solve this issue, I upgraded the alpakka-sqs library dependency to include a fix and updated avatar deletion method to use Ignore and Delete instead of Ack() and RequeueWithDelay().