### PR TITLE
Downgrade Akka dependencies to versions with non-commercial licences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dynamo-local/
 node_modules/
 *.log
 api/logs
+.bsp

--- a/api/build.sbt
+++ b/api/build.sbt
@@ -60,22 +60,28 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-dynamodb" % amazonawsVersion,
   "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingVersion,
   "org.apache.commons" % "commons-lang3" % apacheCommonsVersion,
-  "com.lightbend.akka" %% "akka-stream-alpakka-sqs" % "5.0.0",
-  "com.typesafe.akka" %% "akka-http" % "10.1.15",
-  "com.typesafe.akka" %% "akka-http-core" % "10.1.15",
+  "com.lightbend.akka" %% "akka-stream-alpakka-sqs" % "3.0.4",
   "com.gu" % "kinesis-logback-appender" % "1.4.2"
 )
 
-sourceDirectory in webappPrepare := (sourceDirectory in Compile).value / "resources/webapp"
+// Pin Akka versions to last available non-commercially licensed versions
+val akkaOverrides = Seq(
+  "com.typesafe.akka" %% "akka-stream" % "2.6.21",
+  "com.typesafe.akka" %% "akka-http" % "10.2.10"
+)
+
+dependencyOverrides ++= akkaOverrides
+
+webappPrepare / sourceDirectory := (Compile / sourceDirectory).value / "resources/webapp"
 
 containerPort := 8900
 
-mainClass in Compile := Some("com.gu.adapters.http.JettyLauncher")
+Compile / mainClass := Some("com.gu.adapters.http.JettyLauncher")
 
 // package stuff - note, assumes presence of cfn and rr files
-packageName in Universal := normalizedName.value
-riffRaffPackageType := (packageZipTarball in Universal).value
-mappings in Universal ++= directory("conf")
+Universal / packageName := normalizedName.value
+riffRaffPackageType := (Universal / packageZipTarball).value
+Universal / mappings ++= directory("conf")
 // See the README (## Deploying the app) to understand how the *.yaml files are provided at build time.
 riffRaffArtifactResources += (file(
   "platform/cloudformation/discussion-avatar-api.yaml"

--- a/api/src/main/scala/com/gu/core/akka/Akka.scala
+++ b/api/src/main/scala/com/gu/core/akka/Akka.scala
@@ -2,13 +2,13 @@ package com.gu.core.akka
 
 import akka.actor.{ActorSystem, Scheduler}
 import akka.dispatch.MessageDispatcher
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 
 import scala.concurrent.{ExecutionContextExecutor, Future}
 
 object Akka {
   implicit val system: ActorSystem = ActorSystem()
-  implicit val mat: ActorMaterializer = ActorMaterializer()
+  implicit val mat: Materializer = Materializer(system)
   implicit val defaultDispatcher: ExecutionContextExecutor = system.dispatcher
   val scheduler: Scheduler = system.scheduler
 


### PR DESCRIPTION
From certain versions onwards, Akka libraries have a commercial licence.  
For most libraries this is v4.7+.  But for `akka-stream-alpakka-sqs` this is v5+ and for `akka-http` this is v10.4+.

This PR downgrades some transitive dependencies so that they don't fall under the new licence.
This is a temporary step until we find an alternative to Akka.

Resulting changes in `dependencyList`:

- akka-stream-alpakka-sqs: 5.0.0 => 3.0.4
- akka-actor: 2.7.0 => 2.6.21
- akka-protobuf-v3: 2.7.0 => 2.6.21
- akka-stream: 2.7.0 => 2.6.21
- akka-http: 10.4.0 => 10.2.10
- akka-http-core: 10.4.0 => 10.2.10
- akka-parsing: 10.4.0 => 10.2.10

A Snyk test doesn't reveal any new vulnerabilities as a result of these downgrades.

Tested in Code. Endpoints working fine and no new errors in Elk log.
