### PR TITLE
Migrate to github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
               owner: 'guardian',
               repo: 'discussion-platform',
               workflow_id: 'discussion-avatar-ci.yml',
-              ref: 'mm/avatar-api-gha', // TODO - change to main when discussion-platform PR is merged
+              ref: 'main',
               inputs: {
                 "discussion-avatar-branch": "${{ github.head_ref || github.ref }}",
               }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: Discussion Avatar CI - See Discussion Platform Actions
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger workflow in discussion-platform
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.PAT_ACTIONS_DISCUSSION_PLATFORM }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'guardian',
+              repo: 'discussion-platform',
+              workflow_id: 'discussion-avatar-ci.yml',
+              ref: 'mm/avatar-api-gha', // TODO - change to main when discussion-platform PR is merged
+              inputs: {
+                "discussion-avatar-branch": "${{ github.head_ref || github.ref }}",
+              }
+            })
+
+      - name: Please check discussion-platform for build status
+        run: |
+          echo "Please check discussion-platform for build status"
+          echo "https://github.com/guardian/discussion-platform/actions/workflows/discussion-avatar-ci.yml"

--- a/api/build.sbt
+++ b/api/build.sbt
@@ -2,7 +2,6 @@ import com.typesafe.sbt.SbtNativePackager.autoImport.NativePackagerHelper._
 import scalariform.formatter.preferences._
 
 enablePlugins(
-  RiffRaffArtifact,
   UniversalPlugin,
   JavaAppPackaging,
   JettyPlugin
@@ -80,14 +79,7 @@ Compile / mainClass := Some("com.gu.adapters.http.JettyLauncher")
 
 // package stuff - note, assumes presence of cfn and rr files
 Universal / packageName := normalizedName.value
-riffRaffPackageType := (Universal / packageZipTarball).value
 Universal / mappings ++= directory("conf")
-// See the README (## Deploying the app) to understand how the *.yaml files are provided at build time.
-riffRaffArtifactResources += (file(
-  "platform/cloudformation/discussion-avatar-api.yaml"
-), "cfn/avatar-api.yaml")
-riffRaffArtifactResources += (file("platform/riff-raff.yaml"), "riff-raff.yaml")
-riffRaffArtifactResources += (riffRaffPackageType.value -> s"${name.value}/${name.value}.tgz")
 scalariformPreferences := scalariformPreferences.value
   .setPreference(DanglingCloseParenthesis, Preserve)
   .setPreference(SpacesAroundMultiImports, false)

--- a/api/project/plugins.sbt
+++ b/api/project/plugins.sbt
@@ -7,5 +7,3 @@ resolvers += "sonatype-releases" at "https://oss.sonatype.org/content/repositori
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.1")
-
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.0.0")


### PR DESCRIPTION
## What does this change?

Migrates Avatar API CI from TeamCity to github actions.

This is a slightly uncommon migration in that it inherits from two projects, this project, and also https://github.com/guardian/discussion-platform

So we have to checkout both projects, set up the folders correctly, and then run the CI tests.

The main workflow actually runs in the discussion-platform project, where it was set up in this PR: https://github.com/guardian/discussion-platform/pull/472

But is an added complication where we also need to be able to run this workflow from this project, which we're setting up in this PR. This uses a github personal access token which is able to call a workflow in discussion-platform from this project. This token will have to be regenerated in a year (2024-07-19), or until a better way is found of joining multiple repos, one of which is private (discussion-platform).

Unfortunately status checks don't propagate between the two, so you have to manually check the discussion project to see this status of the workflow. However we so rarely do any development work on discussion avatar that this should suffice for the time being.

This is the example that I used in order to set this up:

https://docs.google.com/document/d/1Xz-gzptICIza0oio0Kza3LWg2a6n_015o0MPu0LGfuU/edit#heading=h.bxtjja1ceh72

This PR has to go in after the one in discussion-platform in order to make this work properly. This was currently tested by using this branch name, which we should change to `main` before merging in.

I've tested this by deploying to CODE and making some API requests with postman.

Before merge make sure to change the branch to `main` as the branch to use in the workflow file. You can see the suggestion in the comment below.