### PR TITLE
Vary target branch of CI workflow by trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  # If this is a merge to main, ie. push event, then use 'main' as the target branch
+  # otherwise, use 'discussion-avatar-target'.
+  # The target branch must exist in the 'discussion-platform' repo!
+  TARGET_BRANCH: "${{ github.event_name == 'push' && 'main' || 'discussion-avatar-target' }}"
+
 jobs:
   CI:
     runs-on: ubuntu-latest
@@ -16,12 +22,14 @@ jobs:
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.PAT_ACTIONS_DISCUSSION_PLATFORM }}
+          # The 'ref' attribute in the following call is used in the target repo as the branch name for Riffraff deploys.
+          # For documentation of this call, see https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: 'guardian',
               repo: 'discussion-platform',
               workflow_id: 'discussion-avatar-ci.yml',
-              ref: 'main',
+              ref: '${{ env.TARGET_BRANCH }}',
               inputs: {
                 "discussion-avatar-branch": "${{ github.head_ref || github.ref }}",
               }


### PR DESCRIPTION
Previously, however the [CI workflow in this repo](https://github.com/guardian/discussion-avatar/blob/main/.github/workflows/ci.yml) was triggered, it would use `main` as the name of the branch in the [discussion-platform](https://github.com/guardian/discussion-platform) repo that Riffraff deployed.  This mean that, as CD was set up on the `main` branch, any change would immediately go into production on any trigger of the CI workflow in this repo.

With this PR, the target branch varies according to whether the CI workflow in this repo was triggered by a push or by the creation/update of a PR or by a manual trigger.  We've set up a dummy branch in `discussion-platform` called `discussion-avatar-target` for deploys that shouldn't automatically go to Prod.  So now only a merge to main in this repo should cause a deployment to production in `discussion-platform`.  To test changes, deploy the `discussion-avatar-target` branch of the `discussion-avatar` project in Riffraff.
