### PR TITLE
feat: Replace `scalaz` with Scala standard library

### DIFF
--- a/api/build.sbt
+++ b/api/build.sbt
@@ -18,7 +18,6 @@ val json4sVersion = "3.5.2"
 val logbackVersion = "1.2.13"
 val logstashEncoderVersion = "7.3"
 val servletApiVersion = "3.1.0"
-val scalazVersion = "7.1.17"
 val identityVersion = "4.31"
 val typesafeConfigVersion = "1.2.1"
 val amazonawsVersion = "1.12.668"
@@ -46,7 +45,6 @@ libraryDependencies ++= Seq(
   "org.json4s" %% "json4s-native" % json4sVersion,
   "org.json4s" %% "json4s-jackson" % json4sVersion,
   "org.scalatra" %% "scalatra-json" % ScalatraVersion,
-  "org.scalaz" %% "scalaz-core" % scalazVersion,
   "org.scalatra" %% "scalatra-scalatest" % ScalatraVersion % Test,
   "org.mockito" % "mockito-core" % "3.1.0" % Test,
   "org.scalatra" %% "scalatra-swagger" % ScalatraVersion,

--- a/api/src/main/scala/com/gu/adapters/http/AuthorizedApiServlet.scala
+++ b/api/src/main/scala/com/gu/adapters/http/AuthorizedApiServlet.scala
@@ -3,20 +3,17 @@ package com.gu.adapters.http
 import com.gu.adapters.http.TokenAuth._
 import org.scalatra._
 import com.gu.core.models.Error
-
-import scalaz.\/
-
 trait AuthorizedApiServlet[Success] {
   this: ScalatraServlet with ServletWithErrorHandling[Error, Success] =>
 
   def apiKeys: List[String]
 
-  def apiGet(transformers: RouteTransformer*)(action: String => \/[Error, (Success, Req)]) = addRoute(Get, transformers, withAuth(action))
-  def apiPut(transformers: RouteTransformer*)(action: String => \/[Error, (Success, Req)]) = addRoute(Put, transformers, withAuth(action))
-  def apiPost(transformers: RouteTransformer*)(action: String => \/[Error, (Success, Req)]) = addRoute(Post, transformers, withAuth(action))
-  def apiDelete(transformers: RouteTransformer*)(action: String => \/[Error, (Success, Req)]) = addRoute(Delete, transformers, withAuth(action))
+  def apiGet(transformers: RouteTransformer*)(action: String => Either[Error, (Success, Req)]) = addRoute(Get, transformers, withAuth(action))
+  def apiPut(transformers: RouteTransformer*)(action: String => Either[Error, (Success, Req)]) = addRoute(Put, transformers, withAuth(action))
+  def apiPost(transformers: RouteTransformer*)(action: String => Either[Error, (Success, Req)]) = addRoute(Post, transformers, withAuth(action))
+  def apiDelete(transformers: RouteTransformer*)(action: String => Either[Error, (Success, Req)]) = addRoute(Delete, transformers, withAuth(action))
 
-  protected def withAuth(response: String => \/[Error, (Success, Req)]): ActionResult = withErrorHandling {
+  protected def withAuth(response: String => Either[Error, (Success, Req)]): ActionResult = withErrorHandling {
     isValidKey(request.header("Authorization"), apiKeys) flatMap response
   }
 

--- a/api/src/main/scala/com/gu/adapters/http/Filter.scala
+++ b/api/src/main/scala/com/gu/adapters/http/Filter.scala
@@ -7,38 +7,40 @@ import com.gu.core.utils.ISODateFormatter
 import org.joda.time.DateTime
 import org.scalatra.Params
 
-import scalaz.{Success, _}
-
 object Filter {
 
-  def fromParams[A](params: Params): InvalidFilters \/ Filters = {
-    val status: Validation[NonEmptyList[String], Status] = params.get("status") match {
-      case Some(Inactive.asString) => Success(Inactive)
-      case Some(Approved.asString) => Success(Approved)
-      case Some(Rejected.asString) => Success(Rejected)
-      case Some(Pending.asString) => Success(Pending)
-      case Some(invalid) => Failure(NonEmptyList(s"'$invalid' is not a valid status type. Must be '${Inactive.asString}', '${Approved.asString}', '${Rejected.asString}', or '${Pending.asString}'."))
-      case None => Success(Approved)
+  def fromParams[A](params: Params): Either[InvalidFilters, Filters] = {
+    val status: Either[List[String], Status] = params.get("status") match {
+      case Some(Inactive.asString) => Right(Inactive)
+      case Some(Approved.asString) => Right(Approved)
+      case Some(Rejected.asString) => Right(Rejected)
+      case Some(Pending.asString) => Right(Pending)
+      case Some(invalid) => Left(List(s"'$invalid' is not a valid status type. Must be '${Inactive.asString}', '${Approved.asString}', '${Rejected.asString}', or '${Pending.asString}'."))
+      case None => Right(Approved)
     }
 
-    val since: Validation[NonEmptyList[String], Option[DateTime]] = params.get("since") match {
-      case Some(s) => attempt(Some(ISODateFormatter.parse(s))).validation
-        .leftMap(_ => NonEmptyList(s"'$s' is not a valid datetime format for 'since'. Must be 'YYYY-MM-DDThh:mm:ssZ'"))
-      case None => Success(None)
+    val since: Either[List[String], Option[DateTime]] = params.get("since") match {
+      case Some(s) => attempt(Some(ISODateFormatter.parse(s))).toEither
+        .left.map(_ => List(s"'$s' is not a valid datetime format for 'since'. Must be 'YYYY-MM-DDThh:mm:ssZ'"))
+      case None => Right(None)
     }
 
-    val until: Validation[NonEmptyList[String], Option[DateTime]] = params.get("until") match {
-      case Some(s) => attempt(Some(ISODateFormatter.parse(s))).validation
-        .leftMap(_ => NonEmptyList(s"'$s' is not a valid datetime format for 'until'. Must be 'YYYY-MM-DDThh:mm:ssZ'"))
-      case None => Success(None)
+    val until: Either[List[String], Option[DateTime]] = params.get("until") match {
+      case Some(s) => attempt(Some(ISODateFormatter.parse(s))).toEither
+        .left.map(_ => List(s"'$s' is not a valid datetime format for 'until'. Must be 'YYYY-MM-DDThh:mm:ssZ'"))
+      case None => Right(None)
     }
 
-    val order: Validation[NonEmptyList[String], Option[OrderBy]] = params.get("order") match {
-      case Some(Descending.asString) => Success(Some(Descending))
-      case Some(Ascending.asString) => Success(Some(Ascending))
-      case Some(invalid) => Failure(NonEmptyList(s"'$invalid' is not a valid order type. Must be '${Ascending.asString}' or '${Descending.asString}' (default)."))
-      case None => Success(None)
+    val order: Either[List[String], Option[OrderBy]] = params.get("order") match {
+      case Some(Descending.asString) => Right(Some(Descending))
+      case Some(Ascending.asString) => Right(Some(Ascending))
+      case Some(invalid) => Left(List(s"'$invalid' is not a valid order type. Must be '${Ascending.asString}' or '${Descending.asString}' (default)."))
+      case None => Right(None)
     }
+
+    val errors = List(status, since, until, order).collect {
+      case Left(err) => err
+    }.flatten
 
     val filters = for {
       s <- status
@@ -48,8 +50,8 @@ object Filter {
     } yield Filters(s, f, b, o)
 
     filters
-      .ensure(NonEmptyList("Cannot specify both 'since' and 'until' parameters"))(f => f.since.isEmpty || f.until.isEmpty)
-      .leftMap(invalidFilters).disjunction
+      .filterOrElse(f => f.since.isEmpty || f.until.isEmpty, List("Cannot specify both 'since' and 'until' parameters"))
+      .left.map(_ => invalidFilters(errors))
   }
 
   def queryString(f: Filters): String = {

--- a/api/src/main/scala/com/gu/adapters/http/ServletWithErrorHandling.scala
+++ b/api/src/main/scala/com/gu/adapters/http/ServletWithErrorHandling.scala
@@ -2,21 +2,19 @@ package com.gu.adapters.http
 
 import org.scalatra._
 
-import scalaz.\/
-
 trait ServletWithErrorHandling[Error, Success] { this: ScalatraServlet =>
 
-  def getWithErrors(transformers: RouteTransformer*)(action: => \/[Error, (Success, Req)]) = addRoute(Get, transformers, withErrorHandling(action))
-  def putWithErrors(transformers: RouteTransformer*)(action: => \/[Error, (Success, Req)]) = addRoute(Put, transformers, withErrorHandling(action))
-  def postWithErrors(transformers: RouteTransformer*)(action: => \/[Error, (Success, Req)]) = addRoute(Post, transformers, withErrorHandling(action))
-  def deleteWithErrors(transformers: RouteTransformer*)(action: => \/[Error, (Success, Req)]) = addRoute(Delete, transformers, withErrorHandling(action))
+  def getWithErrors(transformers: RouteTransformer*)(action: => Either[Error, (Success, Req)]) = addRoute(Get, transformers, withErrorHandling(action))
+  def putWithErrors(transformers: RouteTransformer*)(action: => Either[Error, (Success, Req)]) = addRoute(Put, transformers, withErrorHandling(action))
+  def postWithErrors(transformers: RouteTransformer*)(action: => Either[Error, (Success, Req)]) = addRoute(Post, transformers, withErrorHandling(action))
+  def deleteWithErrors(transformers: RouteTransformer*)(action: => Either[Error, (Success, Req)]) = addRoute(Delete, transformers, withErrorHandling(action))
 
-  def withErrorHandling(response: => \/[Error, (Success, Req)]): ActionResult = {
+  def withErrorHandling(response: => Either[Error, (Success, Req)]): ActionResult = {
     (handleSuccess orElse handleError)(response)
   }
 
-  protected def handleSuccess: PartialFunction[\/[Error, (Success, Req)], ActionResult]
+  protected def handleSuccess: PartialFunction[Either[Error, (Success, Req)], ActionResult]
 
-  protected def handleError[A]: PartialFunction[\/[Error, A], ActionResult]
+  protected def handleError[A]: PartialFunction[Either[Error, A], ActionResult]
 
 }

--- a/api/src/main/scala/com/gu/adapters/http/responses.scala
+++ b/api/src/main/scala/com/gu/adapters/http/responses.scala
@@ -3,8 +3,6 @@ package com.gu.adapters.http
 import com.gu.adapters.http.Links._
 import com.gu.core.models.{Avatar, UserCleaned, UserDeleted}
 
-import scalaz.NonEmptyList
-
 case class Link(rel: String, href: String)
 
 sealed trait Argo
@@ -43,7 +41,7 @@ object ErrorResponse {
     ErrorResponse(None, msg, Nil)
   }
 
-  def apply(msg: String, errors: NonEmptyList[String]): ErrorResponse = {
-    ErrorResponse(None, msg, errors.list)
+  def apply(msg: String, errors: List[String]): ErrorResponse = {
+    ErrorResponse(None, msg, errors)
   }
 }

--- a/api/src/main/scala/com/gu/adapters/queue/SqsDeletionConsumer.scala
+++ b/api/src/main/scala/com/gu/adapters/queue/SqsDeletionConsumer.scala
@@ -11,7 +11,6 @@ import org.apache.pekko
 import org.apache.pekko.stream.connectors.sqs.MessageAction
 import org.apache.pekko.stream.connectors.sqs.MessageAction.{Delete, Ignore}
 import org.apache.pekko.stream.connectors.sqs.scaladsl.{SqsAckSink, SqsSource}
-import scalaz.{NonEmptyList, \/}
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.Message
@@ -47,17 +46,17 @@ class SqsDeletionConsumer(props: SqsDeletionConsumerProps, avatarStore: AvatarSt
 object SqsDeletionConsumer extends LazyLogging {
   def deleteUser(m: Message, avatarStore: AvatarStore): Future[MessageAction] = Pekko.executeBlocking {
 
-    val eventUserId = DeletionEvent.userId(m.body()).toRight(InvalidUserId("Unable to get userId from sqs message", NonEmptyList(m.body)))
+    val eventUserId = DeletionEvent.userId(m.body()).toRight(InvalidUserId("Unable to get userId from sqs message", List(m.body)))
 
-    val result: \/[Error, MessageAction] = for {
-      userId <- \/.fromEither(eventUserId)
+    val result: Either[Error, MessageAction] = for {
+      userId <- eventUserId
       user <- User.userFromId(userId)
       deleted <- avatarStore.deleteAll(user)
     } yield {
       logger.info(s"Successfully deleted $deleted")
       Delete(m)
     }
-    result.leftMap { e =>
+    result.left.map { e =>
       logger.error(s"Failed to process delete event $m", e)
       // If the avatar can't be deleted, don’t change that message, and let it reappear in the queue after the visibility timeout
       Ignore(m)

--- a/api/src/main/scala/com/gu/core/models/User.scala
+++ b/api/src/main/scala/com/gu/core/models/User.scala
@@ -3,13 +3,12 @@ package com.gu.core.models
 import com.gu.core.utils.ErrorHandling._
 import com.gu.core.models.Errors._
 
-import scalaz.{NonEmptyList, \/}
-
 case class User(id: String)
 
 object User {
-  def userFromId(userId: String): Error \/ User = {
+  def userFromId(userId: String): Either[Error, User] = {
     attempt(User(userId))
-      .leftMap(_ => invalidUserId(NonEmptyList("Expected userId, found: " + userId)))
+      .toEither
+      .left.map(_ => invalidUserId(List("Expected userId, found: " + userId)))
   }
 }

--- a/api/src/main/scala/com/gu/core/models/errors.scala
+++ b/api/src/main/scala/com/gu/core/models/errors.scala
@@ -1,77 +1,74 @@
 package com.gu.core.models
-
-import scalaz.NonEmptyList
-
 sealed trait Error {
   val message: String
-  val errors: NonEmptyList[String]
+  val errors: List[String]
 }
-case class InvalidContentType(message: String, errors: NonEmptyList[String]) extends Error
-case class InvalidFilters(message: String, errors: NonEmptyList[String]) extends Error
-case class AvatarNotFound(message: String, errors: NonEmptyList[String]) extends Error
-case class DynamoRequestFailed(message: String, errors: NonEmptyList[String]) extends Error
-case class TokenAuthorizationFailed(message: String, errors: NonEmptyList[String]) extends Error
-case class UserAuthorizationFailed(message: String, errors: NonEmptyList[String]) extends Error
-case class IOFailed(message: String, errors: NonEmptyList[String]) extends Error
-case class UnableToReadStatusRequest(message: String, errors: NonEmptyList[String]) extends Error
-case class InvalidUserId(message: String, errors: NonEmptyList[String]) extends Error
-case class UnableToReadAvatarRequest(message: String, errors: NonEmptyList[String]) extends Error
-case class InvalidMimeType(message: String, errors: NonEmptyList[String]) extends Error
-case class InvalidIsSocialFlag(message: String, errors: NonEmptyList[String]) extends Error
-case class UserDeletionFailed(message: String, errors: NonEmptyList[String]) extends Error
-case class OAuthTokenAuthorizationFailed(message: String, errors: NonEmptyList[String], statusCode: Int) extends Error
+case class InvalidContentType(message: String, errors: List[String]) extends Error
+case class InvalidFilters(message: String, errors: List[String]) extends Error
+case class AvatarNotFound(message: String, errors: List[String]) extends Error
+case class DynamoRequestFailed(message: String, errors: List[String]) extends Error
+case class TokenAuthorizationFailed(message: String, errors: List[String]) extends Error
+case class UserAuthorizationFailed(message: String, errors: List[String]) extends Error
+case class IOFailed(message: String, errors: List[String]) extends Error
+case class UnableToReadStatusRequest(message: String, errors: List[String]) extends Error
+case class InvalidUserId(message: String, errors: List[String]) extends Error
+case class UnableToReadAvatarRequest(message: String, errors: List[String]) extends Error
+case class InvalidMimeType(message: String, errors: List[String]) extends Error
+case class InvalidIsSocialFlag(message: String, errors: List[String]) extends Error
+case class UserDeletionFailed(message: String, errors: List[String]) extends Error
+case class OAuthTokenAuthorizationFailed(message: String, errors: List[String], statusCode: Int) extends Error
 
 object Errors {
 
-  def invalidContentType(errors: NonEmptyList[String]): InvalidContentType =
+  def invalidContentType(errors: List[String]): InvalidContentType =
     InvalidContentType(
       "Invalid content type. Support types are: 'multipart/form-data' or 'application/json'.",
       errors
     )
 
-  def invalidFilters(errors: NonEmptyList[String]): InvalidFilters =
+  def invalidFilters(errors: List[String]): InvalidFilters =
     InvalidFilters("Invalid filter parameters", errors)
 
-  def avatarNotFound(errors: NonEmptyList[String]): AvatarNotFound =
+  def avatarNotFound(errors: List[String]): AvatarNotFound =
     AvatarNotFound("Avatar not found", errors)
 
-  def ioFailed(errors: NonEmptyList[String]): IOFailed =
+  def ioFailed(errors: List[String]): IOFailed =
     IOFailed("IO operation failed", errors)
 
-  def dynamoRequestFailed(errors: NonEmptyList[String]): DynamoRequestFailed =
+  def dynamoRequestFailed(errors: List[String]): DynamoRequestFailed =
     DynamoRequestFailed("DynamoDB request failed", errors)
 
-  def tokenAuthorizationFailed(errors: NonEmptyList[String]): TokenAuthorizationFailed =
+  def tokenAuthorizationFailed(errors: List[String]): TokenAuthorizationFailed =
     TokenAuthorizationFailed("Unable to get API access token. Must be provided in Authorization header as: 'Bearer token=[key]'", errors)
 
-  def userAuthorizationFailed(errors: NonEmptyList[String]): UserAuthorizationFailed =
+  def userAuthorizationFailed(errors: List[String]): UserAuthorizationFailed =
     UserAuthorizationFailed("Unable to read user cookie. Must be provided in Authorization header as: 'Bearer cookie=[cookie]'", errors)
 
-  def unableToReadStatusRequest(errors: NonEmptyList[String]): UnableToReadStatusRequest = {
+  def unableToReadStatusRequest(errors: List[String]): UnableToReadStatusRequest = {
     UnableToReadStatusRequest("Unable to read status request", errors)
   }
 
-  def unableToReadAvatarRequest(errors: NonEmptyList[String]): UnableToReadStatusRequest = {
+  def unableToReadAvatarRequest(errors: List[String]): UnableToReadStatusRequest = {
     UnableToReadStatusRequest("Unable to read avatar request", errors)
   }
 
-  def invalidUserId(errors: NonEmptyList[String]): InvalidUserId = {
+  def invalidUserId(errors: List[String]): InvalidUserId = {
     InvalidUserId("Invalid user ID", errors)
   }
 
-  def invalidIsSocialFlag(errors: NonEmptyList[String]): InvalidIsSocialFlag = {
+  def invalidIsSocialFlag(errors: List[String]): InvalidIsSocialFlag = {
     InvalidIsSocialFlag("Invalid isSocial boolean flag", errors)
   }
 
-  def invalidMimeType(errors: NonEmptyList[String]): InvalidMimeType = {
+  def invalidMimeType(errors: List[String]): InvalidMimeType = {
     InvalidMimeType("Invalid mime type", errors)
   }
 
-  def deletionFailed(errors: NonEmptyList[String]): UserDeletionFailed = {
+  def deletionFailed(errors: List[String]): UserDeletionFailed = {
     UserDeletionFailed("Unable to delete one or more records for the user", errors)
   }
 
-  def oauthTokenAuthorizationFailed(errors: NonEmptyList[String], statusCode: Int): OAuthTokenAuthorizationFailed = {
+  def oauthTokenAuthorizationFailed(errors: List[String], statusCode: Int): OAuthTokenAuthorizationFailed = {
     OAuthTokenAuthorizationFailed("OAuth Token Authorization Failed", errors, statusCode)
   }
 }

--- a/api/src/test/scala/com/gu/adapters/http/AuthenticationTests.scala
+++ b/api/src/test/scala/com/gu/adapters/http/AuthenticationTests.scala
@@ -6,7 +6,6 @@ import com.gu.identity.auth._
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSuite, Matchers}
-import scalaz.{-\/, NonEmptyList, \/-}
 
 class AuthenticationTests extends FunSuite with Matchers with MockitoSugar {
 
@@ -25,7 +24,7 @@ class AuthenticationTests extends FunSuite with Matchers with MockitoSugar {
         Some(scGuUCookie),
         None,
         AccessScope.readSelf
-      ) shouldBe \/-(User("identity-id"))
+      ) shouldBe Right(User("identity-id"))
     }
   }
 
@@ -38,7 +37,7 @@ class AuthenticationTests extends FunSuite with Matchers with MockitoSugar {
         Some(scGuUCookie),
         None,
         AccessScope.readSelf
-      ) shouldBe -\/(Errors.userAuthorizationFailed(NonEmptyList("invalid cookie")))
+      ) shouldBe Left(Errors.userAuthorizationFailed(List("invalid cookie")))
     }
   }
 
@@ -48,7 +47,7 @@ class AuthenticationTests extends FunSuite with Matchers with MockitoSugar {
         None,
         None,
         AccessScope.readSelf
-      ) shouldBe -\/(Errors.userAuthorizationFailed(NonEmptyList("No secure cookie or access token in request")))
+      ) shouldBe Left(Errors.userAuthorizationFailed(List("No secure cookie or access token in request")))
     }
   }
 
@@ -56,7 +55,7 @@ class AuthenticationTests extends FunSuite with Matchers with MockitoSugar {
     new Mocks {
       val token = "token"
       when(oktaLocalValidator.parsedClaimsFromAccessToken(AccessToken(token), List(AccessScope.readSelf))).thenReturn(Right(DefaultAccessClaims("oktaId", "test@test.com", "123", None)))
-      authenticationService.authenticateUser(None, Some(s"Bearer $token"), AccessScope.readSelf) shouldBe \/-(User("123"))
+      authenticationService.authenticateUser(None, Some(s"Bearer $token"), AccessScope.readSelf) shouldBe Right(User("123"))
     }
   }
 
@@ -67,7 +66,7 @@ class AuthenticationTests extends FunSuite with Matchers with MockitoSugar {
       authenticationService.authenticateUser(
         None, Some(s"Bearer $token"),
         AccessScope.readSelf
-      ) shouldBe -\/(Errors.oauthTokenAuthorizationFailed(NonEmptyList("Token is invalid or expired"), 401))
+      ) shouldBe Left(Errors.oauthTokenAuthorizationFailed(List("Token is invalid or expired"), 401))
     }
   }
 }

--- a/api/src/test/scala/com/gu/adapters/http/AvatarServletTests.scala
+++ b/api/src/test/scala/com/gu/adapters/http/AvatarServletTests.scala
@@ -10,7 +10,6 @@ import com.gu.core.store.AvatarStore
 import com.gu.utils.TestHelpers
 import org.mockito.Mockito._
 import org.scalatest.mockito.MockitoSugar
-import scalaz.\/-
 
 class AvatarServletTests extends TestHelpers with MockitoSugar {
 
@@ -76,7 +75,7 @@ class AvatarServletTests extends TestHelpers with MockitoSugar {
 
   test("Get personal avatar by user ID using cookie") {
     val (userId, cookie) = testSecureCookie
-    when(authenticationService.authenticateUser(Some(cookie), None, AccessScope.readSelf)).thenReturn(\/-(User(userId)))
+    when(authenticationService.authenticateUser(Some(cookie), None, AccessScope.readSelf)).thenReturn(Right(User(userId)))
     checkGetAvatar(
       s"/avatars/user/me/active",
       Some(cookie),
@@ -87,7 +86,7 @@ class AvatarServletTests extends TestHelpers with MockitoSugar {
 
   test("Get personal avatar by user ID using oauth access token") {
     val (userId, token) = testAccessToken
-    when(authenticationService.authenticateUser(None, Some(token), AccessScope.readSelf)).thenReturn(\/-(User(userId)))
+    when(authenticationService.authenticateUser(None, Some(token), AccessScope.readSelf)).thenReturn(Right(User(userId)))
     checkGetAvatar(
       s"/avatars/user/me/active",
       None,
@@ -99,7 +98,7 @@ class AvatarServletTests extends TestHelpers with MockitoSugar {
   test("Post avatar using cookie") {
     val file = new File("src/test/resources/avatar.gif")
     val (userId, cookie) = testSecureCookie
-    when(authenticationService.authenticateUser(Some(cookie), None, AccessScope.updateSelf)).thenReturn(\/-(User(userId)))
+    when(authenticationService.authenticateUser(Some(cookie), None, AccessScope.updateSelf)).thenReturn(Right(User(userId)))
 
     postAvatar(
       "/avatars",
@@ -115,7 +114,7 @@ class AvatarServletTests extends TestHelpers with MockitoSugar {
   test("Post avatar using oauth access token") {
     val file = new File("src/test/resources/avatar.gif")
     val (userId, token) = testAccessToken
-    when(authenticationService.authenticateUser(None, Some(token), AccessScope.updateSelf)).thenReturn(\/-(User(userId)))
+    when(authenticationService.authenticateUser(None, Some(token), AccessScope.updateSelf)).thenReturn(Right(User(userId)))
 
     postAvatar(
       "/avatars",
@@ -131,7 +130,7 @@ class AvatarServletTests extends TestHelpers with MockitoSugar {
   test("Social Avatar should default to Inactive status") {
     val file = new File("src/test/resources/avatar.gif")
     val (userId, cookie) = testSecureCookie
-    when(authenticationService.authenticateUser(Some(cookie), None, AccessScope.updateSelf)).thenReturn(\/-(User(userId)))
+    when(authenticationService.authenticateUser(Some(cookie), None, AccessScope.updateSelf)).thenReturn(Right(User(userId)))
 
     postAvatar(
       "/avatars",
@@ -147,7 +146,7 @@ class AvatarServletTests extends TestHelpers with MockitoSugar {
   test("Error response if bad isSocial parameter") {
     val file = new File("src/test/resources/avatar.gif")
     val (userId, cookie) = testSecureCookie
-    when(authenticationService.authenticateUser(Some(cookie), None, AccessScope.updateSelf)).thenReturn(\/-(User(userId)))
+    when(authenticationService.authenticateUser(Some(cookie), None, AccessScope.updateSelf)).thenReturn(Right(User(userId)))
 
     postError(
       "/avatars",

--- a/api/src/test/scala/com/gu/adapters/store/AvatarStoreTest.scala
+++ b/api/src/test/scala/com/gu/adapters/store/AvatarStoreTest.scala
@@ -8,7 +8,6 @@ import com.gu.core.utils.KVLocationFromID
 import org.joda.time.DateTime
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FlatSpec, Matchers}
-import scalaz.\/-
 
 class AvatarStoreTest extends FlatSpec with Matchers with MockitoSugar {
 
@@ -30,7 +29,7 @@ class AvatarStoreTest extends FlatSpec with Matchers with MockitoSugar {
 
   "after uploading an avatar it" should "become active and public on approve" in new WithStore {
     val avatar = uploadAvatar("orig")
-    avatarStore.updateStatus(avatar.id, Approved) shouldBe \/-(UpdatedAvatar(avatar.copy(isActive = true, status = Approved)))
+    avatarStore.updateStatus(avatar.id, Approved) shouldBe Right(UpdatedAvatar(avatar.copy(isActive = true, status = Approved)))
     kvStore.getKey(storeProps.kvTable, avatar.id).get.isActive shouldBe true
     fileStore.get(storeProps.fsPublicBucket, s"user/$userId").get shouldBe "orig"
   }
@@ -40,7 +39,7 @@ class AvatarStoreTest extends FlatSpec with Matchers with MockitoSugar {
     avatarStore.updateStatus(originalAvatar.id, Approved)
 
     val avatar = uploadAvatar("new")
-    avatarStore.updateStatus(avatar.id, Approved) shouldBe \/-(UpdatedAvatar(avatar.copy(isActive = true, status = Approved)))
+    avatarStore.updateStatus(avatar.id, Approved) shouldBe Right(UpdatedAvatar(avatar.copy(isActive = true, status = Approved)))
 
     kvStore.getKey(storeProps.kvTable, avatar.id).get.isActive shouldBe true
     fileStore.get(storeProps.fsPublicBucket, s"user/$userId").get shouldBe "new"
@@ -55,7 +54,7 @@ class AvatarStoreTest extends FlatSpec with Matchers with MockitoSugar {
   "rejecting an avatar" should "delete the public avatar and set active to false but not delete the file" in new WithStore {
     val avatar = uploadAvatar("orig")
     avatarStore.updateStatus(avatar.id, Approved)
-    avatarStore.updateStatus(avatar.id, Rejected) shouldBe \/-(UpdatedAvatar(avatar.copy(isActive = false, status = Rejected)))
+    avatarStore.updateStatus(avatar.id, Rejected) shouldBe Right(UpdatedAvatar(avatar.copy(isActive = false, status = Rejected)))
 
     fileStore.exists(storeProps.fsRawBucket, KVLocationFromID(avatar.id)) shouldBe true
     fileStore.exists(storeProps.fsRawBucket, KVLocationFromID(avatar.id)) shouldBe true
@@ -68,7 +67,7 @@ class AvatarStoreTest extends FlatSpec with Matchers with MockitoSugar {
     avatarStore.updateStatus(original.id, Approved)
 
     val avatar = uploadAvatar("new")
-    avatarStore.updateStatus(avatar.id, Rejected) shouldBe \/-(UpdatedAvatar(avatar.copy(isActive = false, status = Rejected)))
+    avatarStore.updateStatus(avatar.id, Rejected) shouldBe Right(UpdatedAvatar(avatar.copy(isActive = false, status = Rejected)))
 
     fileStore.exists(storeProps.fsPublicBucket, s"user/$userId") shouldBe true
   }
@@ -76,7 +75,7 @@ class AvatarStoreTest extends FlatSpec with Matchers with MockitoSugar {
   "receiving Inactive on an active avatar" should "make the avatar inactive but not delete the public image" in new WithStore {
     val original = uploadAvatar("orig")
     avatarStore.updateStatus(original.id, Approved)
-    avatarStore.updateStatus(original.id, Pending) shouldBe \/-(UpdatedAvatar(original.copy(isActive = false, status = Pending)))
+    avatarStore.updateStatus(original.id, Pending) shouldBe Right(UpdatedAvatar(original.copy(isActive = false, status = Pending)))
     fileStore.exists(storeProps.fsPublicBucket, s"user/$userId") shouldBe true
     kvStore.getKey(storeProps.kvTable, original.id).get.isActive shouldBe false
   }


### PR DESCRIPTION

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

As part of the Scala 2.13 upgrade we needed to update Scalaz to a
version that is compatible with Scala 2.13. This would have involved a
considerable syntax change and introduce a lot of boiler plate due to
[this](https://github.com/scalaz/scalaz/pull/1603) change.

This commit replaces the use of Scalaz with the Scala standard library
where possible. The following changes were made:
 - Scalaz Disjunctions `\/` were replaced with `Either`. For the most
   most part in our codebase `Eithers` are used in the same way as
   `Disjunctions` were used.

   In Scala 2.11 `Disjunctions` likely would have been more preferable
   than `Either` due to having a "right side bias" meaning any `.map`
   or similar operations on the Disjunction would target the right side.
   However since Scala 2.12 `Either` has been improved to also have
   a "right side" bias.

 - Replace Scalaz `_.left` and `_.right` implicits with `Left(_)` and
   `Right(_)` explicit constructors. I personally prefer the explicit
   version of the constructors as I find the implicits a little less
   readable.

 - Replaced Scalaz `Validation` with `Either`. We have to do a little
   more work to get the same functionality as `Eithers` will fail fast
   on failiures, whilst `Validation` can acumulate failiures.

   In our case we have
   multiple filters that we wish to combine together and get a list of
   failed filters.

 - Replace Scalaz `NonEmptyList` with `List`. This is a bit of a
   regression as we lose some type safety.

## How to test

Tested in CODE by uploading an avatar to my profile, and aproving it in modtools. I was then able to see the new avatar in my public discussion profile.  Then deleted my avatar in modtools and saw that it disappeared from my public profile (after clearing cache).

CI is currently broken on this repo but you can trigger the CI manually by going to the discussion-platform repo and invoking the 'Discussion Avatar CI' workflow manually: https://github.com/guardian/discussion-platform/actions/runs/14597398894
