### PR TITLE
feat(dependencies): Update to Java 21

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-java corretto-11.0.25.9.1
+java corretto-21.0.7.6.1

--- a/api/build.sbt
+++ b/api/build.sbt
@@ -10,7 +10,7 @@ enablePlugins(
 organization := "com.gu"
 name := "avatar-api"
 version := "1.0"
-scalaVersion := "2.12.8"
+scalaVersion := "2.12.18"
 
 val ScalatraVersion = "2.6.3"
 val jettyVersion = "9.4.56.v20240826"
@@ -64,6 +64,11 @@ libraryDependencies ++= Seq(
 libraryDependencies ~= { deps =>
   deps.map(_.excludeAll(ExclusionRule(organization = "com.typesafe.akka")))
 }
+
+// Scalatra has not updated to scala-xml 2.0.0 yet.
+// Tell SBT to ignore the version conflict. This is fairly accepted practice for scala-xml: https://github.com/sbt/sbt/issues/6997
+// Long term fix is that we should upgrade to Scalatra 3.x
+ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 
 webappPrepare / sourceDirectory := (Compile / sourceDirectory).value / "resources/webapp"
 

--- a/api/project/build.properties
+++ b/api/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.3
+sbt.version=1.9.0

--- a/api/project/plugins.sbt
+++ b/api/project/plugins.sbt
@@ -2,10 +2,12 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
 addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "4.0.1")
 
-resolvers += "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/"
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
+// sbt-scalariform has not updated to scala-xml 2.0.0 yet.
+// Tell SBT to ignore the version conflict. This is fairly accepted practice for scala-xml: https://github.com/sbt/sbt/issues/6997
+// Long term fix is that we should switch to sbt-scalafmt
+libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
-
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.1")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.1")
 
 addDependencyTreePlugin

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -56,7 +56,7 @@ deployments:
           PrivateBucket: /account/services/private.config.bucket
       amiParametersToTags:
         AMI:
-          Recipe: arm-ubuntu-jammy-discussion-java11-cdk-base
+          Recipe: arm-ubuntu-jammy-discussion-java21-cdk-base
           BuiltBy: amigo
           AmigoStage: PROD
       amiEncrypted: true


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Bumps Avatar to Java 21. This makes my local development a little bit more pleasant as Scala Metals doesn't like Java <17.

Additionally bumps Scala to `2.12.18` and SBT to `1.9`, the [minimum supported versions for Java 21 ](https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html).

## How to test

Deployed to CODE, updated my avatar, posted a comment. Did not see any errors in logs.