### PR TITLE
feat(dependencies): Upgrades Scalatra to `3.1.1` and Json4s to `4.0.7`, their latest respective versions.

### DIFF
--- a/api/build.sbt
+++ b/api/build.sbt
@@ -12,9 +12,9 @@ name := "avatar-api"
 version := "1.0"
 scalaVersion := "2.12.18"
 
-val ScalatraVersion = "2.6.3"
+val ScalatraVersion = "3.1.1"
 val jettyVersion = "9.4.56.v20240826"
-val json4sVersion = "3.5.2"
+val json4sVersion = "4.0.7"
 val logbackVersion = "1.2.13"
 val logstashEncoderVersion = "7.3"
 val servletApiVersion = "3.1.0"
@@ -35,7 +35,7 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "org.scalatra" %% "scalatra" % ScalatraVersion,
+  "org.scalatra" %% "scalatra-javax" % ScalatraVersion,
   "ch.qos.logback" % "logback-classic" % logbackVersion,
   "ch.qos.logback" % "logback-access" % logbackVersion,
   "net.logstash.logback" % "logstash-logback-encoder" % logstashEncoderVersion,
@@ -44,10 +44,11 @@ libraryDependencies ++= Seq(
   "javax.servlet" % "javax.servlet-api" % servletApiVersion,
   "org.json4s" %% "json4s-native" % json4sVersion,
   "org.json4s" %% "json4s-jackson" % json4sVersion,
-  "org.scalatra" %% "scalatra-json" % ScalatraVersion,
-  "org.scalatra" %% "scalatra-scalatest" % ScalatraVersion % Test,
+  "org.json4s" %% "json4s-ext" % json4sVersion,
+  "org.scalatra" %% "scalatra-json-javax" % ScalatraVersion,
+  "org.scalatra" %% "scalatra-scalatest-javax" % ScalatraVersion % Test,
   "org.mockito" % "mockito-core" % "3.1.0" % Test,
-  "org.scalatra" %% "scalatra-swagger" % ScalatraVersion,
+  "org.scalatra" %% "scalatra-swagger-javax" % ScalatraVersion,
   "com.gu.identity" %% "identity-auth-core" % identityVersion,
   "com.typesafe" % "config" % typesafeConfigVersion,
   "com.amazonaws" % "aws-java-sdk-ses" % amazonawsVersion,
@@ -65,9 +66,9 @@ libraryDependencies ~= { deps =>
   deps.map(_.excludeAll(ExclusionRule(organization = "com.typesafe.akka")))
 }
 
-// Scalatra has not updated to scala-xml 2.0.0 yet.
+// identity-auth-core relies on `lift-json` which has not been updated to scala-xml 2.0.0
 // Tell SBT to ignore the version conflict. This is fairly accepted practice for scala-xml: https://github.com/sbt/sbt/issues/6997
-// Long term fix is that we should upgrade to Scalatra 3.x
+// Long term fix is that we release a new version of identity-auth-core that uses Json4s instead of lift-json
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 
 webappPrepare / sourceDirectory := (Compile / sourceDirectory).value / "resources/webapp"

--- a/api/build.sbt
+++ b/api/build.sbt
@@ -48,6 +48,7 @@ libraryDependencies ++= Seq(
   "org.scalatra" %% "scalatra-json-javax" % ScalatraVersion,
   "org.scalatra" %% "scalatra-scalatest-javax" % ScalatraVersion % Test,
   "org.mockito" % "mockito-core" % "3.1.0" % Test,
+  "org.scalatestplus" %% "mockito-5-12" % "3.2.19.0" % Test,
   "org.scalatra" %% "scalatra-swagger-javax" % ScalatraVersion,
   "com.gu.identity" %% "identity-auth-core" % identityVersion,
   "com.typesafe" % "config" % typesafeConfigVersion,

--- a/api/src/main/scala/com/gu/adapters/http/AvatarServlet.scala
+++ b/api/src/main/scala/com/gu/adapters/http/AvatarServlet.scala
@@ -43,7 +43,7 @@ class AvatarServlet(
   // but as a stop gap, simulate the behaviour of 2.3.
   override protected def augmentSimpleRequest(): Unit = {
     super.augmentSimpleRequest()
-    if (response.headers.get(AccessControlAllowOriginHeader).isEmpty) {
+    if (response.getHeader(AccessControlAllowOriginHeader).isEmpty) {
       response.setHeader(AccessControlAllowOriginHeader, request.headers.getOrElse(OriginHeader, ""))
     }
   }
@@ -237,7 +237,7 @@ class AvatarServlet(
       .left.map(_ => invalidIsSocialFlag(List(s"'${param.get}' is not a valid isSocial flag")))
   }
 
-  def uploadAvatar(request: RichRequest, user: User, fileParams: Map[String, FileItem]): Either[Error, CreatedAvatar] = {
+  def uploadAvatar(request: RichRequest, user: User, fileParams: FileSingleParams): Either[Error, CreatedAvatar] = {
     request.contentType match {
       case Some("application/json") | Some("text/json") =>
         for {

--- a/api/src/main/scala/com/gu/adapters/http/AvatarServlet.scala
+++ b/api/src/main/scala/com/gu/adapters/http/AvatarServlet.scala
@@ -43,7 +43,8 @@ class AvatarServlet(
   // but as a stop gap, simulate the behaviour of 2.3.
   override protected def augmentSimpleRequest(): Unit = {
     super.augmentSimpleRequest()
-    if (response.getHeader(AccessControlAllowOriginHeader).isEmpty) {
+    val accessControlAllowOriginHeader = response.getHeader(AccessControlAllowOriginHeader);
+    if (response.getHeader(AccessControlAllowOriginHeader) == null) {
       response.setHeader(AccessControlAllowOriginHeader, request.headers.getOrElse(OriginHeader, ""))
     }
   }

--- a/api/src/main/scala/com/gu/adapters/http/AvatarServlet.scala
+++ b/api/src/main/scala/com/gu/adapters/http/AvatarServlet.scala
@@ -185,7 +185,7 @@ class AvatarServlet(
 
   apiPut("/avatars/:id/status", operation(putAvatarStatus)) { _ =>
     for {
-      sr <- statusRequestFromBody(parsedBody)
+      sr <- statusRequestFromBody(request.body)
       updated <- store.updateStatus(params("id"), sr.status)
       req = Req(apiUrl, request.getPathInfo)
     } yield (updated, req)
@@ -266,8 +266,8 @@ class AvatarServlet(
       .left.map(_ => unableToReadAvatarRequest(List("Could not parse request body")))
   }
 
-  def statusRequestFromBody(parsedBody: JValue): Either[Error, StatusRequest] = {
-    attempt(parsedBody.extract[StatusRequest])
+  def statusRequestFromBody(body: String): Either[Error, StatusRequest] = {
+    attempt(parse(body).extract[StatusRequest])
       .toEither
       .left.map(_ => unableToReadStatusRequest(List("Could not parse request body")))
   }

--- a/api/src/main/scala/com/gu/adapters/http/AvatarSwagger.scala
+++ b/api/src/main/scala/com/gu/adapters/http/AvatarSwagger.scala
@@ -2,6 +2,8 @@ package com.gu.adapters.http
 
 import org.scalatra.ScalatraServlet
 import org.scalatra.swagger.{ApiInfo, NativeSwaggerBase, Swagger}
+import org.scalatra.swagger.LicenseInfo
+import org.scalatra.swagger.ContactInfo
 
 class ResourcesApp(implicit val swagger: Swagger) extends ScalatraServlet with NativeSwaggerBase
 
@@ -9,9 +11,15 @@ object AvatarApiInfo extends ApiInfo(
   title = "Guardian Avatar API",
   description = "Docs for the Avatar API",
   termsOfServiceUrl = "https//github.com/guardian/avatar",
-  contact = "discussiondev@theguardian.com",
-  license = "To be determined",
-  licenseUrl = "To be added"
+  contact = ContactInfo(
+    name = "Discussion Dev",
+    url = "https://github.com/orgs/guardian/teams/discussion",
+    email = "discussiondev@theguardian.com"
+  ),
+  license = LicenseInfo(
+    name = "To be determined",
+    url = "To be added"
+  ),
 )
 
 class AvatarSwagger extends Swagger(Swagger.SpecVersion, "1.0.0", AvatarApiInfo)

--- a/api/src/main/scala/com/gu/adapters/http/IOUtils.scala
+++ b/api/src/main/scala/com/gu/adapters/http/IOUtils.scala
@@ -8,6 +8,7 @@ import com.gu.core.utils.ErrorHandling._
 import org.scalatra.servlet.FileItem
 
 import scala.util.Try
+import org.scalatra.servlet.FileSingleParams
 
 object IOUtils {
   def readBytesAndCloseInputStream(is: InputStream): Either[Error, Array[Byte]] = {
@@ -25,7 +26,7 @@ object IOUtils {
       .left.map(_ => unableToReadAvatarRequest(List("Unable to load image from url: " + url)))
   }
 
-  def readBytesFromFile(fileParams: Map[String, FileItem]): Either[Error, (String, Array[Byte])] = {
+  def readBytesFromFile(fileParams: FileSingleParams): Either[Error, (String, Array[Byte])] = {
     for {
       file <- attempt(fileParams("file")).toEither
         .left.map(_ => unableToReadAvatarRequest(List("Could not parse request body")))

--- a/api/src/main/scala/com/gu/adapters/http/Image.scala
+++ b/api/src/main/scala/com/gu/adapters/http/Image.scala
@@ -9,6 +9,7 @@ import com.gu.core.models.Error
 import com.gu.core.models.Errors.invalidMimeType
 import com.gu.core.utils.ErrorHandling.attempt
 import org.scalatra.servlet.FileItem
+import org.scalatra.servlet.FileSingleParams
 
 object Image {
 
@@ -19,7 +20,7 @@ object Image {
     } yield (bytes, mimeType)
   }
 
-  def getImageFromFile(fileParams: Map[String, FileItem]): Either[Error, (Array[Byte], String, String)] = {
+  def getImageFromFile(fileParams: FileSingleParams): Either[Error, (Array[Byte], String, String)] = {
     for {
       nameAndBytes <- readBytesFromFile(fileParams)
       (fname, bytes) = nameAndBytes

--- a/api/src/main/scala/com/gu/adapters/http/JsonFormats.scala
+++ b/api/src/main/scala/com/gu/adapters/http/JsonFormats.scala
@@ -6,8 +6,6 @@ import org.json4s.ext.JodaTimeSerializers
 import org.json4s.{CustomSerializer, DefaultFormats, FieldSerializer}
 
 object JsonFormats {
-  val links = FieldSerializer[Argo]({ case ("links", Nil) => None })
-
   val status = new CustomSerializer[Status](format => (
     {
       case JString(Inactive.asString) => Inactive
@@ -25,7 +23,6 @@ object JsonFormats {
 
   val all =
     DefaultFormats +
-      links +
       status ++
       JodaTimeSerializers.all
 }

--- a/api/src/test/scala/com/gu/adapters/http/AuthenticationTests.scala
+++ b/api/src/test/scala/com/gu/adapters/http/AuthenticationTests.scala
@@ -4,10 +4,11 @@ import cats.effect.IO
 import com.gu.core.models.{Errors, User}
 import com.gu.identity.auth._
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 
-class AuthenticationTests extends FunSuite with Matchers with MockitoSugar {
+class AuthenticationTests extends AnyFunSuite with Matchers with MockitoSugar {
 
   trait Mocks {
     val idapiAuthService: IdapiAuthService = mock[IdapiAuthService]

--- a/api/src/test/scala/com/gu/adapters/http/AvatarServletTests.scala
+++ b/api/src/test/scala/com/gu/adapters/http/AvatarServletTests.scala
@@ -9,7 +9,7 @@ import com.gu.core.models._
 import com.gu.core.store.AvatarStore
 import com.gu.utils.TestHelpers
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class AvatarServletTests extends TestHelpers with MockitoSugar {
 

--- a/api/src/test/scala/com/gu/adapters/http/ImageValidatorTests.scala
+++ b/api/src/test/scala/com/gu/adapters/http/ImageValidatorTests.scala
@@ -3,9 +3,10 @@ package com.gu.adapters.http
 import java.io.{File, FileInputStream}
 
 import com.gu.adapters.http.IOUtils.readBytesAndCloseInputStream
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class ImageValidatorTests extends FunSuite with Matchers {
+class ImageValidatorTests extends AnyFunSuite with Matchers {
 
   def test(path: String, isValid: Boolean): Unit = {
     val file = new File(path)

--- a/api/src/test/scala/com/gu/adapters/queue/DeletionEventTest.scala
+++ b/api/src/test/scala/com/gu/adapters/queue/DeletionEventTest.scala
@@ -1,9 +1,10 @@
 package com.gu.adapters.queue
 
 import com.gu.core.models.DeletionEvent
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 
-class DeletionEventTest extends FlatSpec with Matchers {
+class DeletionEventTest extends AnyFlatSpec with Matchers {
 
   "DeletionEvent" should "deserialise deletion event correctly" in {
     val eventData =

--- a/api/src/test/scala/com/gu/adapters/queue/SqsDeleteQueueTest.scala
+++ b/api/src/test/scala/com/gu/adapters/queue/SqsDeleteQueueTest.scala
@@ -6,15 +6,16 @@ import org.apache.pekko.stream.connectors.sqs.MessageAction
 import org.mockito.Mockito._
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FlatSpec, Matchers}
 
 import software.amazon.awssdk.services.sqs.model.Message
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 
-class SqsDeleteQueueTest extends FlatSpec with Matchers with MockitoSugar with ScalaFutures {
+class SqsDeleteQueueTest extends AnyFlatSpec with Matchers with MockitoSugar with ScalaFutures {
 
   trait DeletionEventHandlerScope {
     val eventHandlerProps = SqsDeletionConsumerProps("queueUrl", "region")

--- a/api/src/test/scala/com/gu/adapters/store/AvatarStoreTest.scala
+++ b/api/src/test/scala/com/gu/adapters/store/AvatarStoreTest.scala
@@ -6,10 +6,11 @@ import com.gu.core.models._
 import com.gu.core.store.AvatarStore
 import com.gu.core.utils.KVLocationFromID
 import org.joda.time.DateTime
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatestplus.mockito.MockitoSugar
 
-class AvatarStoreTest extends FlatSpec with Matchers with MockitoSugar {
+class AvatarStoreTest extends AnyFlatSpec with Matchers with MockitoSugar {
 
   trait WithStore {
     val config = Config()

--- a/api/src/test/scala/com/gu/core/utils/utils.scala
+++ b/api/src/test/scala/com/gu/core/utils/utils.scala
@@ -1,9 +1,10 @@
 package com.gu.core.utils
 
 import com.gu.core.utils
-import org.scalatest.{Matchers, FunSuite}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class KVLocationFromId extends FunSuite with Matchers {
+class KVLocationFromId extends AnyFunSuite with Matchers {
 
   test("Make key-value store location from ID") {
     val avatarId = "20364a44-a914-4edd-a7de-4aeb621a2ab5"
@@ -11,7 +12,7 @@ class KVLocationFromId extends FunSuite with Matchers {
   }
 }
 
-class UnicodeEscapedFromFilename extends FunSuite with Matchers {
+class UnicodeEscapedFromFilename extends AnyFunSuite with Matchers {
 
   test("Make Unicode escaped version from filename") {
     val originalFilename = "üe.JPG"

--- a/api/src/test/scala/com/gu/utils/TestHelpers.scala
+++ b/api/src/test/scala/com/gu/utils/TestHelpers.scala
@@ -7,11 +7,11 @@ import com.gu.core.models.Status
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods._
 import org.json4s.native.Serialization._
-import org.scalatest.FunSuiteLike
 import org.scalatra.test.ClientResponse
 import org.scalatra.test.scalatest.ScalatraSuite
+import org.scalatest.funsuite.AnyFunSuiteLike
 
-trait TestHelpers extends ScalatraSuite with FunSuiteLike {
+trait TestHelpers extends ScalatraSuite with AnyFunSuiteLike {
 
   protected def apiKey: String
   protected def apiUrl: String


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Upgrades Scalatra to `3.1.1` and Json4s to `4.0.7`, their latest respective versions. Ideally bringing as many dependencies up to date so that its not scary to merge Scala Steward PRs anymore.

Scalatra and Json4s both had some breaking changes that I've attempted to handle as gracefully as possible in this PR.

They are as follows:

1. Switch to `scalatra-javax` instead of `scalatra` in our dependencies. As of Scalatra 3 the core artifact has split to allow users to pick between Javax or Jakarta. We were previously using Javax.
2. Always return `links` in our API responses even if its an empty array. The previous behaviour was to not include `links` in our API response, this was impacting our tests as they tried to use the same class to parse our JSON responses which had `links` as a non optional field. This default behaviour was rightly changed in https://github.com/json4s/json4s/issues/198
3. Handle parsing the request body ourselves in the Status endpoint. For some reason the `PUT /status` endpoint is the only endpoint that lets Scalatra handle parsing the request body instead of doing it ourselves. There hasn't been a breaking change on the API side of things, but the test HTTP client now sets a `Content-Type: text/plain` header which causes the API to not parse the body correctly. Instead of fixing the test I've opted to update the endpoint to work like the rest of our endpoints, always assume the body is JSON.
4. Use `response.getHeader` instead of `response.headers.get` as the later was removed in https://github.com/scalatra/scalatra/pull/886 . Annoyingly this is a bit of a regression has response.getHeader can return `null`, whilst the previous `response.headers.get` returned an Optional.

## How to test
Deply to CODE. Tested setting an avatar, approving it, and then seeing it on the Comments page. Also tried Rejecting my avatar in modtools just to make sure that the Status endpoint still worked after my change.