### PR TITLE
feat(dependencies): Upgrade to Scala `2.13.16`

### DIFF
--- a/api/build.sbt
+++ b/api/build.sbt
@@ -9,7 +9,7 @@ enablePlugins(
 organization := "com.gu"
 name := "avatar-api"
 version := "1.0"
-scalaVersion := "2.12.18"
+scalaVersion := "2.13.16"
 
 val ScalatraVersion = "3.1.1"
 val jettyVersion = "12.0.20"
@@ -21,7 +21,7 @@ val servletApiVersion = "6.0.0"
 val identityVersion = "4.31"
 val typesafeConfigVersion = "1.2.1"
 val amazonawsVersion = "1.12.668"
-val scalaLoggingVersion = "3.6.0"
+val scalaLoggingVersion = "3.9.5"
 val apacheCommonsVersion = "3.4"
 
 val guardianReleases =

--- a/api/src/test/scala/com/gu/adapters/store/store.scala
+++ b/api/src/test/scala/com/gu/adapters/store/store.scala
@@ -67,7 +67,7 @@ class TestFileStore(s3ProcessedBucket: String) extends FileStore {
   def delete(bucket: String, keys: String*): Either[models.Error, Unit] = {
     val paths = keys.map(key => path(bucket, key))
 
-    files = files.filterKeys(key => !paths.contains(key))
+    files = files.filterKeys(key => !paths.contains(key)).toMap
 
     Right(())
   }
@@ -156,7 +156,7 @@ class TestKVStore(dynamoTable: String) extends KVStore {
   }
 
   def delete(table: String, ids: List[String]): Either[Error, DeleteResponse] = {
-    docs = docs.filterKeys(id => !ids.map(k => s"$dynamoTable/${k}").contains(id))
+    docs = docs.filterKeys(id => !ids.map(k => s"$dynamoTable/${k}").contains(id)).toMap
     Right(DeleteResponse(ids))
   }
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Bumps Scala to `2.13.16`. The latest Scala 2.x version.

## How to test

Deployed to CODE and tested uploading, approving, and seeing a new Avatar.
