### PR TITLE
chore: Remove root project from Scala Steward config

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -4,4 +4,4 @@
 # It is possible to have multiple scala projects in a single repository. In that case the folders containing the projects (build.sbt folders)
 # are specified using the buildRoots property. Note that the paths used there are relative and if the repo directory itself also contains a build.sbt the dot can be used to specify it.
 # Default: ["."]
-buildRoots = [ ".", "api" ]
+buildRoots = [ "api" ]


### PR DESCRIPTION
This is to fix the Scala Steward job from failing.
https://github.com/guardian/scala-steward-public-repos/actions/runs/16291377184/job/46001971173#step:6:1586