### PR TITLE
dynamo iteration bug fix

### DIFF
--- a/api/src/main/scala/com/gu/adapters/store/Store.scala
+++ b/api/src/main/scala/com/gu/adapters/store/Store.scala
@@ -142,11 +142,12 @@ case class Dynamo(client: DynamoDbClient, fs: FileStore, props: DynamoProperties
 
     for {
       qr <- result.map(_.lastEvaluatedKey())
+      hasMore = !qr.isEmpty
       items <- result.map(_.items().asScala)
       avatars = items.map(item => asAvatar(item.asScala.toMap)).flatMap(_.toOption)
     } yield {
       val orderedAvatars = until.map(_ => avatars.reverse).getOrElse(avatars).toList
-      QueryResponse(orderedAvatars, true)
+      QueryResponse(orderedAvatars, hasMore)
     }
   }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This fixes a but that causes an infinite loop when fetching all user avatars to clean up inactive ones.
